### PR TITLE
Create user answers list in result page

### DIFF
--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -1,0 +1,23 @@
+<template>
+  <p>{{ $t('quiz.result.showUserAnswers') }}</p>
+  <ul>
+    <div v-for="userAnswer in userAnswers" :key="userAnswer.id">
+      <li v-if="userAnswer === '× '">× {{ $t('quiz.result.blank') }}</li>
+      <li v-else>{{ userAnswer }}</li>
+    </div>
+  </ul>
+</template>
+
+<script>
+export default {
+  name: 'WordQuizResult',
+  props: {
+    userAnswers: {
+      type: Array,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped></style>

--- a/app/javascript/components/word-quiz.vue
+++ b/app/javascript/components/word-quiz.vue
@@ -1,55 +1,67 @@
 <template>
   <div class="grid justify-items-stretch place-content-center">
     <div class="w-96">
-      <p>{{ $t('quiz.question') }}</p>
-      <template
-        v-for="(quizResource, index) in quizResources"
-        :key="quizResource.id">
-        <p v-if="currentIndex === index">
-          {{ quizResource.explanation }}
+      <WordQuizResult
+        v-if="isResult"
+        :userAnswers="userAnswersList"></WordQuizResult>
+      <div v-else>
+        <p>{{ $t('quiz.question') }}</p>
+        <template
+          v-for="(quizResource, index) in quizResources"
+          :key="quizResource.id">
+          <p v-if="currentIndex === index">
+            {{ quizResource.explanation }}
+          </p>
+        </template>
+        <input
+          v-if="!answered"
+          v-model="userAnswer"
+          :placeholder="$t('quiz.placeholder')" />
+        <p v-else>{{ this.userAnswer }}</p>
+        <p v-if="answered && isCorrect">◯ {{ $t('quiz.correct') }}!</p>
+        <p v-else-if="answered && !this.userAnswer">
+          ×{{ $t('quiz.answer', { answer: this.correctAnswer }) }}
         </p>
-      </template>
-      <input
-        v-if="!answered"
-        v-model="userAnswer"
-        :placeholder="$t('quiz.placeholder')" />
-      <p v-else>{{ this.userAnswer }}</p>
-      <p v-if="answered && isCorrect">◯ {{ $t('quiz.correct') }}!</p>
-      <p v-else-if="answered && !this.userAnswer">
-        ×{{ $t('quiz.answer', { answer: this.correctAnswer }) }}
-      </p>
-      <p v-else-if="answered && !isCorrect">
-        ×{{ $t('quiz.incorrect') }}
-        {{ $t('quiz.answer', { answer: this.correctAnswer }) }}
-      </p>
-      <div>
-        <div v-if="isLastQuestion && answered">
-          <p>{{ $t('quiz.completed') }}</p>
-          <button>
-            {{ $t('quiz.result') }}
+        <p v-else-if="answered && !isCorrect">
+          ×{{ $t('quiz.incorrect') }}
+          {{ $t('quiz.answer', { answer: this.correctAnswer }) }}
+        </p>
+        <div>
+          <div v-if="isLastQuestion && answered">
+            <p>{{ $t('quiz.completed') }}</p>
+            <button @click="getResult">
+              {{ $t('quiz.resultButton') }}
+            </button>
+          </div>
+          <button v-else-if="answered" @click="getNextQuestion">
+            {{ $t('quiz.next') }}
           </button>
+          <button v-else @click="onSubmit">{{ $t('quiz.submit') }}</button>
         </div>
-        <button v-else-if="answered" @click="getNextQuestion">
-          {{ $t('quiz.next') }}
-        </button>
-        <button v-else @click="onSubmit">{{ $t('quiz.submit') }}</button>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import WordQuizResult from './word-quiz-result.vue'
+
 export default {
   name: 'WordQuiz',
+  components: {
+    WordQuizResult
+  },
   data() {
     return {
       userAnswer: '',
+      userAnswersList: [],
       quizResources: [],
       currentIndex: 0,
       correctAnswer: '',
       answered: false,
       isCorrect: '',
-      isLastQuestion: false
+      isLastQuestion: false,
+      isResult: false
     }
   },
   methods: {
@@ -57,6 +69,7 @@ export default {
       this.getCorrectAnswer()
       this.answered = true
       this.isCorrect = this.checkUserAnswer()
+      this.createUserAnswersList()
     },
     getNextQuestion() {
       this.answered = false
@@ -64,6 +77,9 @@ export default {
       this.checkQuestionIndex()
       this.userAnswer = ''
       this.correctAnswer = ''
+    },
+    getResult() {
+      this.isResult = true
     },
     async fetchQuizResources() {
       const quizResources = await fetch('/api/quiz', {
@@ -89,6 +105,13 @@ export default {
       const lastIndex = this.quizResources.length - 1
       if (this.currentIndex !== lastIndex) return
       this.isLastQuestion = true
+    },
+    createUserAnswersList() {
+      if (this.isCorrect) {
+        this.userAnswersList.push(`◯ ${this.userAnswer}`)
+      } else {
+        this.userAnswersList.push(`× ${this.userAnswer}`)
+      }
     }
   },
   mounted() {

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -9,7 +9,11 @@
         "incorrect": "不正解",
         "answer": "正解は{answer}です",
         "completed": "問題が全て出題されました",
-        "result": "クイズの結果を確認する"
+        "resultButton": "クイズの結果を確認する",
+        "result": {
+            "showUserAnswers": "自分の解答を表示",
+            "blank": "未入力"
+        }
     }
 
 }

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -46,4 +46,41 @@ RSpec.describe 'Quiz' do
       expect(page).not_to have_button '次へ'
     end
   end
+
+  describe 'quiz result' do
+    it 'change the screen from quiz to result' do
+      fill_in('解答を入力', with: 'balcony')
+      click_button 'クイズに解答する'
+      click_button '次へ'
+      fill_in('解答を入力', with: 'veranda')
+      click_button 'クイズに解答する'
+      click_button 'クイズの結果を確認する'
+
+      expect(page).not_to have_content '問題'
+      expect(page).to have_content '自分の解答を表示'
+    end
+
+    it 'show user answers list' do
+      fill_in('解答を入力', with: 'Balcony')
+      click_button 'クイズに解答する'
+      click_button '次へ'
+      fill_in('解答を入力', with: 'wrong answer')
+      click_button 'クイズに解答する'
+      click_button 'クイズの結果を確認する'
+
+      expect(page).to have_content '◯ Balcony'
+      expect(page).to have_content '× wrong answer'
+    end
+
+    it 'show 未入力 if the user answer is blank' do
+      fill_in('解答を入力', with: '')
+      click_button 'クイズに解答する'
+      click_button '次へ'
+      fill_in('解答を入力', with: 'veranda')
+      click_button 'クイズに解答する'
+      click_button 'クイズの結果を確認する'
+
+      expect(page).to have_content '× 未入力'
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #37 

## Summary
クイズで回答したユーザーの答えの一覧をクイズの最終結果画面に表示させた。

本来であればユーザーの答えは`自分の解答を表示`をクリックするまで表示されない仕様だが、デザインは後で入れるためここでは実装しておらず、ユーザーの解答が全て表示されている。