### PR TITLE
Create tag form

### DIFF
--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -20,6 +20,7 @@ class ExpressionsController < ApplicationController
   # POST /expressions or /expressions.json
   def create
     @expression = Expression.new(expression_params)
+    @expression.tags = Tag.find_tags_object(@expression.tags)
 
     respond_to do |format|
       if @expression.save
@@ -64,6 +65,7 @@ class ExpressionsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def expression_params
-    params.require(:expression).permit(:note, expression_items_attributes: [:id, :content, :explanation, { examples_attributes: %i[id content] }])
+    params.require(:expression).permit(:note, expression_items_attributes: [:id, :content, :explanation, { examples_attributes: %i[id content] }],
+                                              tags_attributes: %i[id name])
   end
 end

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -415,7 +415,22 @@
           </li>
           <li>
             <label for="tags">{{ $t('form.tags') }}</label>
-            <input id="tags" name="tags" class="w-full" v-model="tag" />
+            <div>
+              <vue-tags-input
+                id="tags"
+                v-model="tag"
+                :tags="tags"
+                @tags-changed="updateTags"
+                :placeholder="$t('form.howToUseTagInput')"></vue-tags-input>
+              <ul>
+                <li v-for="(tagValue, index) in tagsValue" :key="tagValue.id">
+                  <input
+                    type="hidden"
+                    :name="`expression[tags_attributes][${index}][name]`"
+                    :value="tagValue" />
+                </li>
+              </ul>
+            </div>
           </li>
         </ul>
         <button v-if="previousPage === 3" type="button" @click="getThirdPage">
@@ -446,8 +461,13 @@
 </template>
 
 <script>
+import VueTagsInput from '@sipec/vue3-tags-input'
+
 export default {
   name: 'ExpressionsForm',
+  components: {
+    VueTagsInput
+  },
   data() {
     return {
       currentPage: 1,
@@ -490,11 +510,20 @@ export default {
       comparedExpressions: '',
       note: '',
       tag: '',
+      tags: [],
+      tagsValue: [],
       expressionsError: false,
       explanationError: false
     }
   },
   methods: {
+    updateTags(newTags) {
+      this.tags = newTags
+      const tagsArray = newTags.map((tag) => {
+        return tag.text
+      })
+      this.tagsValue = tagsArray
+    },
     getFirstPage() {
       this.currentPage = 1
     },

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -34,6 +34,7 @@
         "note": "メモ（任意）",
         "tags": "タグ（任意）",
         "expressionsError": "英単語又はフレーズを２つ以上入力してください",
+        "howToUseTagInput": "タグ入力後エンターキーで登録",
         "create": "登録"
     }
 

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -7,4 +7,5 @@ class Expression < ApplicationRecord
   accepts_nested_attributes_for :expression_items, reject_if: lambda { |attributes|
     attributes['content'].blank?
   }
+  accepts_nested_attributes_for :tags
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -2,6 +2,8 @@
 
 class Expression < ApplicationRecord
   has_many :expression_items, dependent: :destroy
+  has_many :taggings, dependent: :destroy
+  has_many :tags, through: :taggings
   accepts_nested_attributes_for :expression_items, reject_if: lambda { |attributes|
     attributes['content'].blank?
   }

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,4 +3,10 @@
 class Tag < ApplicationRecord
   has_many :taggings, dependent: :destroy
   has_many :expressions, through: :taggings
+
+  validates :name, presence: true
+
+  def self.find_tags_object(tags_object)
+    tags_object.map { |tag| Tag.find_by(name: tag.name) || tag }
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Tag < ApplicationRecord
+  has_many :taggings, dependent: :destroy
+  has_many :expressions, through: :taggings
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Tagging < ApplicationRecord
+  belongs_to :expression
+  belongs_to :tag
+end

--- a/db/migrate/20230227143739_create_tags.rb
+++ b/db/migrate/20230227143739_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230227145742_create_taggings.rb
+++ b/db/migrate/20230227145742_create_taggings.rb
@@ -1,0 +1,10 @@
+class CreateTaggings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :taggings do |t|
+      t.references :expression, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_24_172612) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_145742) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_24_172612) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "expression_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expression_id"], name: "index_taggings_on_expression_id"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "uid", null: false
     t.string "name", null: false
@@ -46,4 +61,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_24_172612) do
 
   add_foreign_key "examples", "expression_items"
   add_foreign_key "expression_items", "expressions"
+  add_foreign_key "taggings", "expressions"
+  add_foreign_key "taggings", "tags"
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@hotwired/stimulus": "^3.2.1",
         "@hotwired/turbo-rails": "^7.2.4",
+        "@sipec/vue3-tags-input": "^3.0.4",
         "esbuild": "^0.16.15",
         "vue-i18n": "^9.2.2"
       },
@@ -328,6 +329,17 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@sipec/vue3-tags-input": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@sipec/vue3-tags-input/-/vue3-tags-input-3.0.4.tgz",
+      "integrity": "sha512-zE4OiFkWvlvvGT3FZQ9hRrvJW935VPW0fe4K03SxM5Q/UQZMqph763UHXTuyK1orWNQMTbDx9tKPLIMZTiDXLA==",
+      "dependencies": {
+        "vue": "^3.0.0-beta.1"
+      },
+      "peerDependencies": {
+        "vue": "3.x"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -410,7 +422,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
       "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
-      "peer": true,
       "dependencies": {
         "@vue/shared": "3.2.45"
       }
@@ -431,7 +442,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
       "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.2.45",
         "@vue/shared": "3.2.45"
@@ -441,7 +451,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
       "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
-      "peer": true,
       "dependencies": {
         "@vue/runtime-core": "3.2.45",
         "@vue/shared": "3.2.45",
@@ -452,7 +461,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
       "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.2.45",
         "@vue/shared": "3.2.45"
@@ -890,8 +898,7 @@
     "node_modules/csstype": {
       "version": "2.6.21",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
-      "peer": true
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3570,7 +3577,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
       "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.2.45",
         "@vue/compiler-sfc": "3.2.45",
@@ -3964,6 +3970,14 @@
         "picomatch": "^2.2.2"
       }
     },
+    "@sipec/vue3-tags-input": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@sipec/vue3-tags-input/-/vue3-tags-input-3.0.4.tgz",
+      "integrity": "sha512-zE4OiFkWvlvvGT3FZQ9hRrvJW935VPW0fe4K03SxM5Q/UQZMqph763UHXTuyK1orWNQMTbDx9tKPLIMZTiDXLA==",
+      "requires": {
+        "vue": "^3.0.0-beta.1"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -4040,7 +4054,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
       "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
-      "peer": true,
       "requires": {
         "@vue/shared": "3.2.45"
       }
@@ -4061,7 +4074,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
       "integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
-      "peer": true,
       "requires": {
         "@vue/reactivity": "3.2.45",
         "@vue/shared": "3.2.45"
@@ -4071,7 +4083,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
       "integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
-      "peer": true,
       "requires": {
         "@vue/runtime-core": "3.2.45",
         "@vue/shared": "3.2.45",
@@ -4082,7 +4093,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
       "integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
-      "peer": true,
       "requires": {
         "@vue/compiler-ssr": "3.2.45",
         "@vue/shared": "3.2.45"
@@ -4370,8 +4380,7 @@
     "csstype": {
       "version": "2.6.21",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
-      "peer": true
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "debug": {
       "version": "4.3.4",
@@ -6194,7 +6203,6 @@
       "version": "3.2.45",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
       "integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
-      "peer": true,
       "requires": {
         "@vue/compiler-dom": "3.2.45",
         "@vue/compiler-sfc": "3.2.45",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.2.4",
+    "@sipec/vue3-tags-input": "^3.0.4",
     "esbuild": "^0.16.15",
     "vue-i18n": "^9.2.2"
   },

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tag do
+    name { 'test' }
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  before do
+    FactoryBot.create(:tag)
+  end
+
+  describe '.find_tags_object' do
+    it 'return a new tag object when the tag does not exist on database' do
+      new_tag_object = described_class.find_tags_object([described_class.new(name: 'test2')])
+
+      expect(new_tag_object[0].id).to eq nil
+      expect(new_tag_object[0].name).to eq 'test2'
+      expect { new_tag_object[0].save }.to change(described_class, :count).by(1)
+    end
+
+    it 'return a tag object from database when the tag exist' do
+      saved_tag_object = described_class.find_tags_object([described_class.new(name: 'test')])
+
+      expect(saved_tag_object[0].id).not_to eq nil
+      expect(saved_tag_object[0].name).to eq 'test'
+      expect { saved_tag_object[0].save }.to change(described_class, :count).by(0)
+    end
+  end
+end

--- a/spec/system/expressions_spec.rb
+++ b/spec/system/expressions_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'create expressions' do
-    context 'when two phrases, the explanations, one example for each and the note are given' do
+    before do
+      FactoryBot.create(:tag)
+    end
+
+    context 'when two phrases, the explanations, one example for each, the note and one tag are given' do
       before do
         fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')
         fill_in('２つ目の英単語 / フレーズ', with: 'at the beach')
@@ -20,17 +24,19 @@ RSpec.describe 'Expressions' do
         fill_in('例文２', with: 'example of at the beach')
         click_button '次へ'
         fill_in('メモ（任意）', with: 'note')
+        fill_in('タグ（任意）', with: 'preposition')
+        find('input#tags').send_keys :return
       end
 
       it 'create data' do
         expect do
           click_button '登録'
           expect(page).to have_content 'Expression was successfully created.'
-        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(2).and change(Example, :count).by(2)
+        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(2).and change(Example, :count).by(2).and change(Tag, :count).by(1)
       end
     end
 
-    context 'when three words, the explanations, one example for one word without the note are given' do
+    context 'when three words, the explanations, one example for one word and tags without the note are given' do
       before do
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
@@ -43,17 +49,21 @@ RSpec.describe 'Expressions' do
         click_button '次へ'
         fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
         click_button '次へ'
+        fill_in('タグ（任意）', with: 'test')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: 'noun')
+        find('input#tags').send_keys :return
       end
 
       it 'create data' do
         expect do
           click_button '登録'
           expect(page).to have_content 'Expression was successfully created.'
-        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(3).and change(Example, :count).by(1)
+        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(3).and change(Example, :count).by(1).and change(Tag, :count).by(1)
       end
     end
 
-    context 'when four words, the explanations, two examples for each without the note are given' do
+    context 'when four words, the explanations, two examples for each and tags without the note are given' do
       before do
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
@@ -76,17 +86,23 @@ RSpec.describe 'Expressions' do
         fill_in('例文１', with: 'first example of word4')
         fill_in('例文２', with: 'second example of word4')
         click_button '次へ'
+        fill_in('タグ（任意）', with: 'test')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: '2023')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: '動詞')
+        find('input#tags').send_keys :return
       end
 
       it 'create data' do
         expect do
           click_button '登録'
           expect(page).to have_content 'Expression was successfully created.'
-        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(4).and change(Example, :count).by(8)
+        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(4).and change(Example, :count).by(8).and change(Tag, :count).by(2)
       end
     end
 
-    context 'when five words, the explanations, three example for two words without the note are given' do
+    context 'when five words, the explanations, three example for two words and one tag without the note are given' do
       before do
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
@@ -110,13 +126,15 @@ RSpec.describe 'Expressions' do
         fill_in('例文２', with: 'second example of word5')
         fill_in('例文３', with: 'third example of word5')
         click_button '次へ'
+        fill_in('タグ（任意）', with: '名詞')
+        find('input#tags').send_keys :return
       end
 
       it 'create data' do
         expect do
           click_button '登録'
           expect(page).to have_content 'Expression was successfully created.'
-        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(5).and change(Example, :count).by(6)
+        end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(5).and change(Example, :count).by(6).and change(Tag, :count).by(1)
       end
     end
   end
@@ -166,6 +184,73 @@ RSpec.describe 'Expressions' do
       it 'no validation error when examples are not given' do
         expect(page).to have_content '{word}について'
         expect(page).not_to have_css '.text-red-600'
+      end
+    end
+
+    describe 'tags' do
+      before do
+        fill_in('１つ目の英単語 / フレーズ', with: 'word1')
+        fill_in('２つ目の英単語 / フレーズ', with: 'word2')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word1')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word2')
+        click_button '次へ'
+        fill_in('タグ（任意）', with: 'English')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: '2023')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: '漢字')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: 'ひらがな')
+        find('input#tags').send_keys :return
+        fill_in('タグ（任意）', with: 'カタカナ')
+        find('input#tags').send_keys :return
+      end
+
+      it 'avoid adding duplicate in English' do
+        fill_in('タグ（任意）', with: 'English')
+        find('input#tags').send_keys :return
+        expect do
+          click_button '登録'
+          expect(page).to have_content 'Expression was successfully created.'
+        end.to change(Tag, :count).by(5)
+      end
+
+      it 'avoid adding duplicate number' do
+        fill_in('タグ（任意）', with: '2023')
+        find('input#tags').send_keys :return
+        expect do
+          click_button '登録'
+          expect(page).to have_content 'Expression was successfully created.'
+        end.to change(Tag, :count).by(5)
+      end
+
+      it 'avoid adding duplicate in Kanji' do
+        fill_in('タグ（任意）', with: '漢字')
+        find('input#tags').send_keys :return
+        expect do
+          click_button '登録'
+          expect(page).to have_content 'Expression was successfully created.'
+        end.to change(Tag, :count).by(5)
+      end
+
+      it 'avoid adding duplicate in Hiragana' do
+        fill_in('タグ（任意）', with: 'ひらがな')
+        find('input#tags').send_keys :return
+        expect do
+          click_button '登録'
+          expect(page).to have_content 'Expression was successfully created.'
+        end.to change(Tag, :count).by(5)
+      end
+
+      it 'avoid adding duplicate in Katakana' do
+        fill_in('タグ（任意）', with: 'カタカナ')
+        find('input#tags').send_keys :return
+        expect do
+          click_button '登録'
+          expect(page).to have_content 'Expression was successfully created.'
+        end.to change(Tag, :count).by(5)
       end
     end
 


### PR DESCRIPTION
## Issue
- #89 

## Summary
新規入力フォームでタグを入力しDBに保存できるようにした。
又既に登録済みのタグに関しては基本的に新規作成されず、既存タグを使って中間テーブルを作成するようにした。
一方、万が一タグの重複が発生しても大きな問題は現時点で発生しないことから、Tagモデルのクラスメソッドでタグの重複がないよう実装。Railsでのバリデーションやデータベースのそのカラムに一意インデックスを作成するなどの実装は行なっていない。