### PR TITLE
Use i18n for notification when expression was created

### DIFF
--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -24,7 +24,7 @@ class ExpressionsController < ApplicationController
 
     respond_to do |format|
       if @expression.save
-        format.html { redirect_to expression_url(@expression), notice: 'Expression was successfully created.' }
+        format.html { redirect_to expression_url(@expression), notice: t('.success') }
         format.json { render :show, status: :created, location: @expression }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,11 +4,11 @@ class SessionsController < ApplicationController
   def create
     user = User.find_or_create_from_auth_hash!(request.env['omniauth.auth'])
     session[:user_id] = user.id
-    redirect_to root_path, notice: 'Successfully logged in!'
+    redirect_to root_path, notice: t('.success')
   end
 
   def destroy
     reset_session
-    redirect_to root_path, notice: 'Successfully logged out!'
+    redirect_to root_path, notice: t('.success')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,6 @@ class UsersController < ApplicationController
   def destroy
     current_user.destroy!
     reset_session
-    redirect_to welcome_path, notice: t('user.deleted_account')
+    redirect_to welcome_path, notice: t('.success')
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,2 +1,4 @@
+p style="color: green" = notice
+
 h1 Home#index
 p Find me in app/views/home/index.html.slim

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,5 +12,4 @@ html
   body
     = render 'shared/header'
     main
-      = notice
       = yield

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -14,6 +14,6 @@ header.mx-9.my-4
               li
                 = button_to 'Log out', logout_path, method: :delete
               li
-                = button_to 'Delete account', me_path, method: :delete, form: { data: { turbo_confirm: t('user.confirm_deletion_of_account') } }
+                = button_to 'Delete account', me_path, method: :delete, form: { data: { turbo_confirm: t('users.confirm_deletion_of_account') } }
         - else
           = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }, class: 'font-medium text-lg'

--- a/app/views/welcome/index.html.slim
+++ b/app/views/welcome/index.html.slim
@@ -1,2 +1,4 @@
+p style="color: green" = notice
+
 h1 Welcome#index
 p Find me in app/views/welcome/index.html.slim

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,3 +2,6 @@ ja:
   user:
     confirm_deletion_of_account: "アカウントを削除しますか？\n \n重要:アカウントを削除すると、このアプリに登録した全てのデータは削除されます。"
     deleted_account: アカウントを削除しました
+  expressions:
+    create:
+      success: 英単語またはフレーズを新規作成しました

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,13 @@
 ja:
-  user:
+  users:
     confirm_deletion_of_account: "アカウントを削除しますか？\n \n重要:アカウントを削除すると、このアプリに登録した全てのデータは削除されます。"
-    deleted_account: アカウントを削除しました
+    destroy:
+      success: アカウントを削除しました
+  sessions:
+    create:
+      success: ログインしました
+    destroy:
+      success: ログアウトしました
   expressions:
     create:
       success: 英単語またはフレーズを新規作成しました

--- a/spec/system/expressions_spec.rb
+++ b/spec/system/expressions_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Expressions' do
       it 'create data' do
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(2).and change(Example, :count).by(2).and change(Tag, :count).by(1)
       end
     end
@@ -58,7 +58,7 @@ RSpec.describe 'Expressions' do
       it 'create data' do
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(3).and change(Example, :count).by(1).and change(Tag, :count).by(1)
       end
     end
@@ -97,7 +97,7 @@ RSpec.describe 'Expressions' do
       it 'create data' do
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(4).and change(Example, :count).by(8).and change(Tag, :count).by(2)
       end
     end
@@ -133,7 +133,7 @@ RSpec.describe 'Expressions' do
       it 'create data' do
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Expression, :count).by(1).and change(ExpressionItem, :count).by(5).and change(Example, :count).by(6).and change(Tag, :count).by(1)
       end
     end
@@ -223,7 +223,7 @@ RSpec.describe 'Expressions' do
         find('input#tags').send_keys :return
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Tag, :count).by(5)
       end
 
@@ -232,7 +232,7 @@ RSpec.describe 'Expressions' do
         find('input#tags').send_keys :return
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Tag, :count).by(5)
       end
 
@@ -241,7 +241,7 @@ RSpec.describe 'Expressions' do
         find('input#tags').send_keys :return
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Tag, :count).by(5)
       end
 
@@ -250,7 +250,7 @@ RSpec.describe 'Expressions' do
         find('input#tags').send_keys :return
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Tag, :count).by(5)
       end
 
@@ -259,7 +259,7 @@ RSpec.describe 'Expressions' do
         find('input#tags').send_keys :return
         expect do
           click_button '登録'
-          expect(page).to have_content 'Expression was successfully created.'
+          expect(page).to have_content '英単語またはフレーズを新規作成しました'
         end.to change(Tag, :count).by(5)
       end
     end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Sessions' do
     it 'show a message when login succeed' do
       visit '/'
       click_button 'Sign up/Log in with Google'
-      expect(page).to have_content 'Successfully logged in!'
+      expect(page).to have_content 'ログインしました'
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe 'Sessions' do
     it 'show a message when logout succeed' do
       find('label', text: user.name).click
       click_button 'Log out'
-      expect(page).to have_content 'Successfully logged out!'
+      expect(page).to have_content 'ログアウトしました'
     end
   end
 end


### PR DESCRIPTION
## Issue
- #58 

## Summary
新規英単語・フレーズが作成された時のトーストをi18nを使って日本語表記に変更した。
またnoticeメッセージがヘッダーコンポーネントで表示されるようになっていたので各viewファイル上で表示されるように変更した。
実装済みのものでi18nが使われていなかったnoticeメッセージをi18nを使用したものに修正し、userコントローラーのi18nのコードの書き方も修正した。