### PR TITLE
Create step navigation for expression form

### DIFF
--- a/app/javascript/VueMounter.js
+++ b/app/javascript/VueMounter.js
@@ -1,6 +1,14 @@
 import { createApp } from 'vue'
 import { createI18n } from 'vue-i18n'
 import ja from './locales/ja.json'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import {
+  faCircleCheck,
+  faPenToSquare
+} from '@fortawesome/free-regular-svg-icons'
+
+library.add(faCircleCheck, faPenToSquare)
 
 export default class VueMounter {
   constructor() {
@@ -26,6 +34,7 @@ export default class VueMounter {
           })
           const app = createApp(component)
           app.use(i18n)
+          app.component('font-awesome-icon', FontAwesomeIcon)
           app.mount(`[data-vue=${name}]`)
         })
       }

--- a/app/javascript/components/expressions-form-step-navigation.vue
+++ b/app/javascript/components/expressions-form-step-navigation.vue
@@ -1,6 +1,36 @@
 <template>
   <ol class="flex flex-row">
-    <div v-if="currentPage === 1">
+    <div v-if="previousPage === 2 && currentPage === 1">
+      <li
+        class="inline-block p-2 bg-yellow-200 border-y-2 border-l-2 border-yellow-200">
+        <h1>
+          <font-awesome-icon icon="fa-regular fa-circle-check" size="xl" />Step1
+        </h1>
+        <p>{{ $t('stepNavigation.wordsOrPhrases') }}</p>
+      </li>
+      <div v-if="!completedStep2" class="inline-block">
+        <li class="p-2 border-y-2 border-r-2 border-gray-300 text-gray-400">
+          <h1>
+            <font-awesome-icon
+              icon="fa-regular fa-pen-to-square"
+              size="xl" />Step2
+          </h1>
+          <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+        </li>
+      </div>
+      <div v-else class="inline-block">
+        <li class="p-2 border-y-2 border-r-2 border-gray-300">
+          <h1>
+            <font-awesome-icon
+              icon="fa-regular fa-circle-check"
+              class="text-yellow-400"
+              size="xl" />Step2
+          </h1>
+          <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+        </li>
+      </div>
+    </div>
+    <div v-else-if="currentPage === 1">
       <li
         class="inline-block p-2 bg-yellow-200 border-y-2 border-r-2 border-yellow-200">
         <h1>
@@ -51,6 +81,15 @@
         <p>{{ $t('stepNavigation.noteAndTags') }}</p>
       </li>
     </div>
+    <div v-else-if="currentPage !== 1 && completedStep2">
+      <li
+        class="inline-block bg-yellow-200 p-2 border-y-2 border-l-2 border-yellow-200">
+        <h1>
+          <font-awesome-icon icon="fa-regular fa-circle-check" size="xl" />Step2
+        </h1>
+        <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+      </li>
+    </div>
     <div v-else-if="currentPage !== 1">
       <li
         class="inline-block p-2 bg-yellow-200 border-y-2 border-r-2 border-yellow-200">
@@ -82,6 +121,14 @@ export default {
   props: {
     currentPage: {
       type: Number,
+      required: true
+    },
+    previousPage: {
+      type: Number,
+      required: true
+    },
+    completedStep2: {
+      type: Boolean,
       required: true
     }
   }

--- a/app/javascript/components/expressions-form-step-navigation.vue
+++ b/app/javascript/components/expressions-form-step-navigation.vue
@@ -1,0 +1,13 @@
+<template>
+$END$
+</template>
+
+<script>
+export default {
+name: "expressions-form-step-navigation"
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/javascript/components/expressions-form-step-navigation.vue
+++ b/app/javascript/components/expressions-form-step-navigation.vue
@@ -1,13 +1,91 @@
 <template>
-$END$
+  <ol class="flex flex-row">
+    <div v-if="currentPage === 1">
+      <li
+        class="inline-block p-2 bg-yellow-200 border-y-2 border-r-2 border-yellow-200">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-pen-to-square"
+            size="xl" />Step1
+        </h1>
+        <p>{{ $t('stepNavigation.wordsOrPhrases') }}</p>
+      </li>
+      <li
+        class="inline-block p-2 border-y-2 border-r-2 border-gray-300 text-gray-400">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-pen-to-square"
+            size="xl" />Step2
+        </h1>
+        <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+      </li>
+    </div>
+    <div v-else>
+      <li class="inline-block p-2 border-y-2 border-l-2 border-gray-300">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-circle-check"
+            class="text-yellow-400"
+            size="xl" />Step1
+        </h1>
+        <p>{{ $t('stepNavigation.wordsOrPhrases') }}</p>
+      </li>
+    </div>
+    <div v-if="currentPage === 7">
+      <li class="inline-block p-2 border-y-2 border-l-2 border-gray-300">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-circle-check"
+            class="text-yellow-400"
+            size="xl" />Step2
+        </h1>
+        <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+      </li>
+      <li
+        class="inline-block p-2 bg-yellow-200 border-y-2 border-r-2 border-yellow-200">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-pen-to-square"
+            size="xl" />Step3
+        </h1>
+        <p>{{ $t('stepNavigation.noteAndTags') }}</p>
+      </li>
+    </div>
+    <div v-else-if="currentPage !== 1">
+      <li
+        class="inline-block p-2 bg-yellow-200 border-y-2 border-r-2 border-yellow-200">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-pen-to-square"
+            size="xl" />Step2
+        </h1>
+        <p>{{ $t('stepNavigation.explanationAndExamples') }}</p>
+      </li>
+    </div>
+    <div v-if="currentPage < 7">
+      <li
+        class="inline-block p-2 border-y-2 border-r-2 border-gray-300 text-gray-400">
+        <h1>
+          <font-awesome-icon
+            icon="fa-regular fa-pen-to-square"
+            size="xl" />Step3
+        </h1>
+        <p>{{ $t('stepNavigation.noteAndTags') }}</p>
+      </li>
+    </div>
+  </ol>
 </template>
 
 <script>
 export default {
-name: "expressions-form-step-navigation"
+  name: 'expressionsFormStepNavigation',
+  props: {
+    currentPage: {
+      type: Number,
+      required: true
+    }
+  }
 }
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -550,7 +550,8 @@ export default {
       })
     },
     isExplanationError(explanation) {
-      this.explanationError = !explanation ? true : false
+      this.explanationError = false
+      if (!explanation) this.explanationError = true
     },
     getFirstPage() {
       this.previousPage = this.currentPage

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="grid justify-items-stretch place-content-center">
+    <ExpressionsFormStepNavigation
+      :current-page="currentPage"></ExpressionsFormStepNavigation>
     <form action="/expressions" method="POST">
       <div v-show="currentPage === 1">
         <p>{{ $t('form.expressions') }}</p>
@@ -462,10 +464,12 @@
 
 <script>
 import VueTagsInput from '@sipec/vue3-tags-input'
+import ExpressionsFormStepNavigation from './expressions-form-step-navigation.vue'
 
 export default {
   name: 'ExpressionsForm',
   components: {
+    ExpressionsFormStepNavigation,
     VueTagsInput
   },
   data() {

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -543,9 +543,7 @@ export default {
         this.fifthExpression
       ]
       expressions.forEach((expression) => {
-        if (expression) {
-          this.expressionsList.push(expression)
-        }
+        if (expression) this.expressionsList.push(expression)
         this.expressionsAmount = this.expressionsList.length
       })
     },
@@ -569,9 +567,8 @@ export default {
         this.fifthExpression
       ])
       if (this.currentPage === 1) {
-        if (this.firstExpression === '' || this.secondExpression === '') {
+        if (this.firstExpression === '' || this.secondExpression === '')
           this.expressionsError = true
-        }
         const previousExpressionsAmount = this.expressionsAmount
         this.calculateExpressionsAmount()
         if (
@@ -581,9 +578,7 @@ export default {
           this.completedStep2 = false
         }
       }
-      if (!this.expressionsError) {
-        this.currentPage = 2
-      }
+      if (!this.expressionsError) this.currentPage = 2
     },
     getThirdPage() {
       this.previousPage = this.currentPage
@@ -641,9 +636,8 @@ export default {
     },
     getSixPage() {
       this.previousPage = this.currentPage
-      if (this.currentPage === 5) {
+      if (this.currentPage === 5)
         this.isExplanationError(this.fourthExpressionDetails.explanation)
-      }
       if (!this.explanationError) {
         this.comparedExpressions = ''
         this.getComparedExpressions([

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -189,7 +189,7 @@
         </ul>
         <button type="button" @click="getSecondPage">{{ $t('back') }}</button>
         <button
-          v-if="thirdExpression || fourthExpression || fifthExpression"
+          v-if="expressionsAmount > 2"
           type="button"
           @click="getFourthPage">
           {{ $t('form.next') }}
@@ -261,7 +261,7 @@
         </ul>
         <button type="button" @click="getThirdPage">{{ $t('back') }}</button>
         <button
-          v-if="fourthExpression || fifthExpression"
+          v-if="expressionsAmount > 3"
           type="button"
           @click="getFifthPage">
           {{ $t('form.next') }}

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -653,8 +653,8 @@ export default {
       this.isExplanationError(explanation)
       this.previousPage = this.currentPage
       if (!this.explanationError) {
-        this.currentPage = 7
         this.completedStep2 = true
+        this.currentPage = 7
       }
     },
     getComparedExpressions(expressionsList) {

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -549,6 +549,9 @@ export default {
         this.expressionsAmount = this.expressionsList.length
       })
     },
+    isExplanationError(explanation) {
+      this.explanationError = !explanation ? true : false
+    },
     getFirstPage() {
       this.previousPage = this.currentPage
       this.currentPage = 1
@@ -584,11 +587,7 @@ export default {
     getThirdPage() {
       this.previousPage = this.currentPage
       if (this.currentPage === 2) {
-        if (!this.firstExpressionDetails.explanation) {
-          this.explanationError = true
-        } else {
-          this.explanationError = false
-        }
+        this.isExplanationError(this.firstExpressionDetails.explanation)
       } else if (this.currentPage === 4) {
         this.explanationError = false
       }
@@ -606,11 +605,7 @@ export default {
     getFourthPage() {
       this.previousPage = this.currentPage
       if (this.currentPage === 3) {
-        if (!this.secondExpressionDetails.explanation) {
-          this.explanationError = true
-        } else {
-          this.explanationError = false
-        }
+        this.isExplanationError(this.secondExpressionDetails.explanation)
       } else if (this.currentPage === 5) {
         this.explanationError = false
       }
@@ -628,11 +623,7 @@ export default {
     getFifthPage() {
       this.previousPage = this.currentPage
       if (this.currentPage === 4) {
-        if (!this.thirdExpressionDetails.explanation) {
-          this.explanationError = true
-        } else {
-          this.explanationError = false
-        }
+        this.isExplanationError(this.thirdExpressionDetails.explanation)
       } else if (this.currentPage === 6) {
         this.explanationError = false
       }
@@ -650,11 +641,7 @@ export default {
     getSixPage() {
       this.previousPage = this.currentPage
       if (this.currentPage === 5) {
-        if (!this.fourthExpressionDetails.explanation) {
-          this.explanationError = true
-        } else {
-          this.explanationError = false
-        }
+        this.isExplanationError(this.fourthExpressionDetails.explanation)
       }
       if (!this.explanationError) {
         this.comparedExpressions = ''
@@ -668,11 +655,7 @@ export default {
       }
     },
     getSevenPage(explanation) {
-      if (!explanation) {
-        this.explanationError = true
-      } else {
-        this.explanationError = false
-      }
+      this.isExplanationError(explanation)
       this.previousPage = this.currentPage
       if (!this.explanationError) {
         this.currentPage = 7

--- a/app/javascript/components/expressions-form.vue
+++ b/app/javascript/components/expressions-form.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="grid justify-items-stretch place-content-center">
     <ExpressionsFormStepNavigation
-      :current-page="currentPage"></ExpressionsFormStepNavigation>
+      :current-page="currentPage"
+      :previous-page="previousPage"
+      :completed-step2="completedStep2"></ExpressionsFormStepNavigation>
     <form action="/expressions" method="POST">
       <div v-show="currentPage === 1">
         <p>{{ $t('form.expressions') }}</p>
@@ -475,12 +477,14 @@ export default {
   data() {
     return {
       currentPage: 1,
-      previousPage: Number,
+      previousPage: 0,
       firstExpression: '',
       secondExpression: '',
       thirdExpression: '',
       fourthExpression: '',
       fifthExpression: '',
+      expressionsList: [],
+      expressionsAmount: 0,
       firstExpressionDetails: {
         explanation: '',
         firstExample: '',
@@ -516,6 +520,7 @@ export default {
       tag: '',
       tags: [],
       tagsValue: [],
+      completedStep2: false,
       expressionsError: false,
       explanationError: false
     }
@@ -528,10 +533,28 @@ export default {
       })
       this.tagsValue = tagsArray
     },
+    calculateExpressionsAmount() {
+      this.expressionsList = []
+      const expressions = [
+        this.firstExpression,
+        this.secondExpression,
+        this.thirdExpression,
+        this.fourthExpression,
+        this.fifthExpression
+      ]
+      expressions.forEach((expression) => {
+        if (expression) {
+          this.expressionsList.push(expression)
+        }
+        this.expressionsAmount = this.expressionsList.length
+      })
+    },
     getFirstPage() {
+      this.previousPage = this.currentPage
       this.currentPage = 1
     },
     getSecondPage() {
+      this.previousPage = this.currentPage
       this.explanationError = false
       this.expressionsError = false
       this.comparedExpressions = ''
@@ -545,12 +568,21 @@ export default {
         if (this.firstExpression === '' || this.secondExpression === '') {
           this.expressionsError = true
         }
+        const previousExpressionsAmount = this.expressionsAmount
+        this.calculateExpressionsAmount()
+        if (
+          this.completedStep2 &&
+          this.expressionsAmount !== previousExpressionsAmount
+        ) {
+          this.completedStep2 = false
+        }
       }
       if (!this.expressionsError) {
         this.currentPage = 2
       }
     },
     getThirdPage() {
+      this.previousPage = this.currentPage
       if (this.currentPage === 2) {
         if (!this.firstExpressionDetails.explanation) {
           this.explanationError = true
@@ -572,6 +604,7 @@ export default {
       }
     },
     getFourthPage() {
+      this.previousPage = this.currentPage
       if (this.currentPage === 3) {
         if (!this.secondExpressionDetails.explanation) {
           this.explanationError = true
@@ -593,6 +626,7 @@ export default {
       }
     },
     getFifthPage() {
+      this.previousPage = this.currentPage
       if (this.currentPage === 4) {
         if (!this.thirdExpressionDetails.explanation) {
           this.explanationError = true
@@ -614,6 +648,7 @@ export default {
       }
     },
     getSixPage() {
+      this.previousPage = this.currentPage
       if (this.currentPage === 5) {
         if (!this.fourthExpressionDetails.explanation) {
           this.explanationError = true
@@ -641,6 +676,7 @@ export default {
       this.previousPage = this.currentPage
       if (!this.explanationError) {
         this.currentPage = 7
+        this.completedStep2 = true
       }
     },
     getComparedExpressions(expressionsList) {

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -36,7 +36,11 @@
         "expressionsError": "英単語又はフレーズを２つ以上入力してください",
         "howToUseTagInput": "タグ入力後エンターキーで登録",
         "create": "登録"
+    },
+    "stepNavigation": {
+        "wordsOrPhrases": "単語又はフレーズ",
+        "explanationAndExamples": "意味・例文",
+        "noteAndTags": "メモ・タグ（任意）"
     }
-
 }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "name": "app",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.3.0",
+        "@fortawesome/free-regular-svg-icons": "^6.3.0",
+        "@fortawesome/vue-fontawesome": "^3.0.3",
         "@hotwired/stimulus": "^3.2.1",
         "@hotwired/turbo-rails": "^7.2.4",
         "@sipec/vue3-tags-input": "^3.0.4",
@@ -80,6 +83,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+      "integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+      "integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-cZnwiVHZ51SVzWHOaNCIA+u9wevZjCuAGSvSYpNlm6A4H4Vhwh8481Bf/5rwheIC3fFKlgXxLKaw8Xeroz8Ntg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz",
+      "integrity": "sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "vue": ">= 3.0.0 < 4"
       }
     },
     "node_modules/@hotwired/stimulus": {
@@ -3803,6 +3848,33 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.3.0.tgz",
+      "integrity": "sha512-4BC1NMoacEBzSXRwKjZ/X/gmnbp/HU5Qqat7E8xqorUtBFZS+bwfGH5/wqOC2K6GV0rgEobp3OjGRMa5fK9pFg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.3.0.tgz",
+      "integrity": "sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.3.0.tgz",
+      "integrity": "sha512-cZnwiVHZ51SVzWHOaNCIA+u9wevZjCuAGSvSYpNlm6A4H4Vhwh8481Bf/5rwheIC3fFKlgXxLKaw8Xeroz8Ntg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.3.0"
+      }
+    },
+    "@fortawesome/vue-fontawesome": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz",
+      "integrity": "sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==",
+      "requires": {}
     },
     "@hotwired/stimulus": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "app",
   "private": "true",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.3.0",
+    "@fortawesome/free-regular-svg-icons": "^6.3.0",
+    "@fortawesome/vue-fontawesome": "^3.0.3",
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.2.4",
     "@sipec/vue3-tags-input": "^3.0.4",

--- a/spec/system/expressions_spec.rb
+++ b/spec/system/expressions_spec.rb
@@ -374,4 +374,180 @@ RSpec.describe 'Expressions' do
       end
     end
   end
+
+  describe 'step navigation' do
+    describe 'on the first page' do
+      it 'check step1' do
+        within('.bg-yellow-200') do
+          expect(page).to have_css '.fa-pen-to-square'
+          expect(page).to have_content 'Step1'
+        end
+      end
+
+      it 'check step2' do
+        within first(:css, '.text-gray-400') do
+          expect(page).to have_css '.fa-pen-to-square'
+          expect(page).to have_content 'Step2'
+        end
+      end
+
+      it 'check step3' do
+        within all('.text-gray-400').last do
+          expect(page).to have_css '.fa-pen-to-square'
+          expect(page).to have_content 'Step3'
+        end
+      end
+    end
+
+    context 'when two expressions are input without clicking any back buttons' do
+      before do
+        fill_in('１つ目の英単語 / フレーズ', with: 'word1')
+        fill_in('２つ目の英単語 / フレーズ', with: 'word2')
+        click_button '次へ'
+      end
+
+      it 'show check circle after completing the step1' do
+        within first(:css, '.border-gray-300') do
+          expect(page).to have_css '.fa-circle-check'
+          expect(page).to have_css '.text-yellow-400'
+        end
+
+        within('.bg-yellow-200') { expect(page).to have_content 'Step2' }
+      end
+
+      it 'show the check circle after completing the step2' do
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word1')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word2')
+        click_button '次へ'
+
+        expect(all('.fa-circle-check').length).to eq 2
+        within('.bg-yellow-200') { expect(page).to have_content 'Step3' }
+      end
+    end
+
+    context 'when three expressions are input with clicking back buttons' do
+      before do
+        fill_in('１つ目の英単語 / フレーズ', with: 'word1')
+        fill_in('２つ目の英単語 / フレーズ', with: 'word2')
+        fill_in('３つ目の英単語 / フレーズ', with: 'word3')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word1')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word2')
+        click_button '次へ'
+      end
+
+      it 'show the check circle after completing the step2' do
+        within('.bg-yellow-200') { expect(page).to have_content 'Step2' }
+
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+
+        expect(all('.fa-circle-check').length).to eq 2
+      end
+
+      it 'check background color when the page is on the note and tags' do
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+
+        expect(page).to have_content 'メモ（任意）'
+        within('.bg-yellow-200') { expect(page).to have_content 'Step3' }
+      end
+
+      it 'check step1 icon after completing the step1 and then go back to the step from step2' do
+        expect(all('.text-yellow-400').length).to eq 1
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        expect(page).to have_content '意味の違いや使い分けを学習したい英単語又はフレーズを入力してください'
+        within('.bg-yellow-200') { expect(page).to have_css '.fa-circle-check' }
+      end
+
+      it 'check step2 icon after completing the step2 and then go back to the step from step3' do
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+        click_button '戻る'
+        expect(page).to have_content '{word}について'
+        within('.bg-yellow-200') do
+          expect(page).to have_css '.fa-circle-check'
+          expect(page).to have_content 'Step2'
+        end
+      end
+
+      it 'check step1 icon after completing the step2 and then go back to the step from step3' do
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+        click_button '戻る'
+        within first(:css, '.border-gray-300') do
+          expect(page).to have_css '.fa-circle-check'
+          expect(page).to have_css '.text-yellow-400'
+        end
+      end
+    end
+
+    context 'when expressions amount change four from three after completing step2' do
+      before do
+        fill_in('１つ目の英単語 / フレーズ', with: 'word1')
+        fill_in('２つ目の英単語 / フレーズ', with: 'word2')
+        fill_in('３つ目の英単語 / フレーズ', with: 'word3')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word1')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word2')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        fill_in('４つ目の英単語 / フレーズ', with: 'word4')
+        click_button '次へ'
+      end
+
+      it 'check step2 icon if it changes' do
+        within('.bg-yellow-200') do
+          expect(page).to have_css '.fa-pen-to-square'
+          expect(page).to have_content 'Step2'
+        end
+      end
+    end
+
+    context 'when expressions amount change four from five after completing step2' do
+      before do
+        fill_in('１つ目の英単語 / フレーズ', with: 'word1')
+        fill_in('２つ目の英単語 / フレーズ', with: 'word2')
+        fill_in('３つ目の英単語 / フレーズ', with: 'word3')
+        fill_in('４つ目の英単語 / フレーズ', with: 'word4')
+        fill_in('５つ目の英単語 / フレーズ', with: 'word5')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word1')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word2')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word3')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word4')
+        click_button '次へ'
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of word5')
+        click_button '次へ'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        click_button '戻る'
+        fill_in('５つ目の英単語 / フレーズ', with: '')
+        click_button '次へ'
+      end
+
+      it 'check step2 icon if it changes' do
+        within('.bg-yellow-200') do
+          expect(page).to have_css '.fa-pen-to-square'
+          expect(page).to have_content 'Step2'
+        end
+      end
+    end
+  end
 end

--- a/spec/system/expressions_spec.rb
+++ b/spec/system/expressions_spec.rb
@@ -180,6 +180,27 @@ RSpec.describe 'Expressions' do
         click_button '次へ'
         expect(page).to have_css '.text-red-600'
       end
+
+      it 'go to the next page once users input the explanation after validation error on the second page' do
+        click_button '次へ'
+        expect(page).to have_css '.text-red-600'
+
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of on the beach')
+        click_button '次へ'
+        expect(page).not_to have_css '.text-red-600'
+      end
+
+      it 'go to the next page once users input the explanation after validation error on the third page' do
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of on the beach')
+        click_button '次へ'
+        click_button '次へ'
+        expect(page).to have_css '.text-red-600'
+
+        fill_in('{word}の意味や前ページで登録した英単語 / フレーズ（{comparison}）との違いを入力してください。', with: 'explanation of at the beach')
+        click_button '次へ'
+        expect(page).not_to have_css '.text-red-600'
+        expect(page).to have_content 'メモ（任意）'
+      end
     end
 
     describe 'examples' do


### PR DESCRIPTION
## Issue
- #66 

## Summary
フォームのステップナビゲーションを作成した。
英単語・フレーズの意味・例文を入力するフォームのページ数は、フォーム1ページ目に入力された英単語・フレーズの数によって出力されるフォーム数が変わってくる。
ステップナビゲーションが一度表示された後にそこに表示されているステップ数が増減するのは違和感があるため、英単語・フレーズの意味・例文を入力するステップは、英単語・フレーズの数に関わらず１ステップとしてカウントすることにした。