### PR TITLE
Fix a bug that order of an expression list change after editing note

### DIFF
--- a/app/controllers/api/expressions_controller.rb
+++ b/app/controllers/api/expressions_controller.rb
@@ -4,7 +4,7 @@ class Api::ExpressionsController < ApplicationController
   before_action :set_expression, only: %i[edit]
 
   def index
-    @expressions = Expression.all
+    @expressions = Expression.order(:created_at)
   end
 
   def edit; end

--- a/app/javascript/components/expressions-list.vue
+++ b/app/javascript/components/expressions-list.vue
@@ -2,7 +2,8 @@
   <ul>
     <li
       v-for="expressionsResource in expressionsResources"
-      :key="expressionsResource.id">
+      :key="expressionsResource.id"
+      class="expression">
       <a :href="`/expressions/${expressionsResource.id}`">{{
         titles[expressionsResource.id]
       }}</a>

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -106,4 +106,33 @@ RSpec.describe 'Expressions' do
       end
     end
   end
+
+  describe 'list order after editing note' do
+    context 'when the note is before editing' do
+      it 'check the list order by expression id 1' do
+        visit '/'
+        within first('li.expression') do
+          expect(page).to have_link 'balcony and Veranda', href: expression_path(1)
+        end
+      end
+    end
+
+    context 'when the note is after editing' do
+      before do
+        visit '/'
+        click_link 'balcony and Veranda'
+        click_link '編集'
+        3.times { click_button '次へ' }
+        fill_in('メモ（任意）', with: 'note is added')
+        click_button '編集する'
+      end
+
+      it 'check if the data is on the same place' do
+        visit '/'
+        within first('li.expression') do
+          expect(page).to have_link 'balcony and Veranda', href: expression_path(1)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #101 

## Summary
英単語・フレーズの一覧画面のデータの並び順をデータが作成された順番に表示させるようにした。