### PR TITLE
Create the function of deleting expressions

### DIFF
--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -22,27 +22,19 @@ class ExpressionsController < ApplicationController
     @expression = Expression.new(expression_params)
     @expression.tags = Tag.find_tags_object(@expression.tags)
 
-    respond_to do |format|
-      if @expression.save
-        format.html { redirect_to expression_url(@expression), notice: t('.success') }
-        format.json { render :show, status: :created, location: @expression }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @expression.errors, status: :unprocessable_entity }
-      end
+    if @expression.save
+      redirect_to expression_url(@expression), notice: t('.success')
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
   # PATCH/PUT /expressions/1 or /expressions/1.json
   def update
-    respond_to do |format|
-      if @expression.update(expression_params)
-        format.html { redirect_to expression_url(@expression), notice: t('.success') }
-        format.json { render :show, status: :ok, location: @expression }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @expression.errors, status: :unprocessable_entity }
-      end
+    if @expression.update(expression_params)
+      redirect_to expression_url(@expression), notice: t('.success')
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -48,12 +48,10 @@ class ExpressionsController < ApplicationController
 
   # DELETE /expressions/1 or /expressions/1.json
   def destroy
+    next_expression = @expression.next
     @expression.destroy
 
-    respond_to do |format|
-      format.html { redirect_to expressions_url, notice: 'Expression was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to expression_path(next_expression), notice: t('.success')
   end
 
   private

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -8,4 +8,8 @@ class Expression < ApplicationRecord
     attributes['content'].blank?
   }
   accepts_nested_attributes_for :tags
+
+  def next
+    Expression.order(:created_at, :id).find_by('created_at >= ? AND id > ?', created_at, id)
+  end
 end

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -40,4 +40,4 @@ div
   '|
   = link_to t('.back'), root_path, data: { turbo: false }
 
-  = button_to 'Destroy this expression', @expression, method: :delete
+  = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,8 @@ ja:
       success: 英単語またはフレーズを新規作成しました
     update:
       success: 英単語またはフレーズを編集しました
+    destroy:
+      success: 英単語又はフレーズを削除しました
     show:
       title: 下記の英単語・フレーズの違いについて
       explanation: 意味
@@ -21,6 +23,8 @@ ja:
       tag: タグ
       back: 英単語・フレーズ一覧に戻る
       edit: 編集
+      delete: 削除
+      confirm_deletion_of_expression: この英単語又はフレーズを本当に削除しますか？
     edit:
       go_to_show: 詳細画面に戻る
       go_to_index: 英単語・フレーズ一覧に戻る

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Expression, type: :model do
+  describe '#next' do
+    it 'get next expression' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      expect(first_expression_items[0].expression.next).to eq second_expression_items[0].expression
+    end
+
+    it 'get next expression even though the next id is missing' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      second_expression_items[0].expression.destroy
+
+      expect(first_expression_items[0].expression.next).to eq third_expression_items[0].expression
+    end
+  end
+end

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -138,4 +138,51 @@ RSpec.describe 'Expressions' do
       end
     end
   end
+
+  describe 'delete expressions' do
+    before do
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      visit '/'
+      click_link 'balcony and Veranda'
+    end
+
+    it 'check if expression is deleted' do
+      expect do
+        click_button '削除'
+        expect(page.accept_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
+        expect(page).to have_content '英単語又はフレーズを削除しました'
+      end.to change(Expression, :count).by(-1).and change(ExpressionItem, :count).by(-2)
+
+      visit '/'
+      expect(page).not_to have_link 'balcony and Veranda'
+    end
+
+    it 'check if the expression is not deleted when cancel button is clicked' do
+      expect do
+        click_button '削除'
+        expect(page.dismiss_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
+        within '.title' do
+          expect(page).to have_content 'balcony'
+        end
+        click_link '英単語・フレーズ一覧に戻る'
+      end.to change(Expression, :count).by(0).and change(ExpressionItem, :count).by(0)
+
+      expect(page).to have_link 'balcony and Veranda'
+    end
+
+    it 'check if the next expression is on the page after deleting expression' do
+      delete_expression_item = ExpressionItem.find_by content: 'balcony'
+      next_expression = delete_expression_item.expression.next
+      accept_confirm do
+        click_button '削除'
+      end
+      expect(page).to have_content '英単語又はフレーズを削除しました'
+
+      next_expression.expression_items.each do |expression_item|
+        within '.title' do
+          expect(page).to have_content expression_item.content
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #61 
- #62 

## Summary
英単語・フレーズを削除できるようにした。
削除後は削除したデータの次に作成した英単語・フレーズの詳細画面に画面遷移するようにした。

またExpressionsコントローラーのcreateとupdateのrespond_toメソッドが不要だったため削除した。