### PR TITLE
Change redirect URL when the last id of expression was deleted or all expressions were deleted

### DIFF
--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -40,10 +40,15 @@ class ExpressionsController < ApplicationController
 
   # DELETE /expressions/1 or /expressions/1.json
   def destroy
-    next_expression = @expression.next
+    expression = @expression.next || @expression.previous
+
     @expression.destroy
 
-    redirect_to expression_path(next_expression), notice: t('.success')
+    if expression
+      redirect_to expression_path(expression), notice: t('.success')
+    else
+      redirect_to root_path, notice: t('.success')
+    end
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
-  def index; end
+  def index
+    @expressions = Expression.all
+  end
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -9,6 +9,10 @@ class Expression < ApplicationRecord
   }
   accepts_nested_attributes_for :tags
 
+  def previous
+    Expression.order(created_at: :desc, id: :desc).find_by('created_at <= ? AND id < ?', created_at, id)
+  end
+
   def next
     Expression.order(:created_at, :id).find_by('created_at >= ? AND id > ?', created_at, id)
   end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,3 +1,7 @@
 p style="color: green" = notice
 
-div(data-vue='ExpressionsList')
+- if @expressions.blank?
+  p
+    = t('.no_data')
+- else
+    div(data-vue='ExpressionsList')

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,7 @@
 ja:
+  home:
+    index:
+      no_data: このリストに登録されている英単語またはフレーズはありません
   users:
     confirm_deletion_of_account: "アカウントを削除しますか？\n \n重要:アカウントを削除すると、このアプリに登録した全てのデータは削除されます。"
     destroy:

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -22,4 +22,23 @@ RSpec.describe Expression, type: :model do
       expect(first_expression_items[0].expression.next).to eq third_expression_items[0].expression
     end
   end
+
+  describe '#previous' do
+    it 'get previous expression' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      expect(second_expression_items[0].expression.previous).to eq first_expression_items[0].expression
+    end
+
+    it 'get previous expression even though the previous id is missing' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      second_expression_items[0].expression.destroy
+
+      expect(third_expression_items[0].expression.previous).to eq first_expression_items[0].expression
+    end
+  end
 end

--- a/spec/system/expressions/expression_delete_spec.rb
+++ b/spec/system/expressions/expression_delete_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Expressions' do
+  describe 'delete first expression' do
+    before do
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      visit '/'
+      click_link 'balcony and Veranda'
+    end
+
+    it 'check if expression is deleted' do
+      expect do
+        click_button '削除'
+        expect(page.accept_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
+        expect(page).to have_content '英単語又はフレーズを削除しました'
+      end.to change(Expression, :count).by(-1).and change(ExpressionItem, :count).by(-2)
+
+      visit '/'
+      expect(page).not_to have_link 'balcony and Veranda'
+    end
+
+    it 'check if the expression is not deleted when cancel button is clicked' do
+      expect do
+        click_button '削除'
+        expect(page.dismiss_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
+        within '.title' do
+          expect(page).to have_content 'balcony'
+        end
+        click_link '英単語・フレーズ一覧に戻る'
+      end.to change(Expression, :count).by(0).and change(ExpressionItem, :count).by(0)
+
+      expect(page).to have_link 'balcony and Veranda'
+    end
+
+    it 'check if the next expression is on the page after deleting expression' do
+      delete_expression_item = ExpressionItem.find_by content: 'balcony'
+      next_expression = delete_expression_item.expression.next
+      accept_confirm do
+        click_button '削除'
+      end
+      expect(page).to have_content '英単語又はフレーズを削除しました'
+
+      next_expression.expression_items.each do |expression_item|
+        within '.title' do
+          expect(page).to have_content expression_item.content
+        end
+      end
+    end
+  end
+
+  describe 'delete another expression' do
+    let(:expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+
+    before do
+      expression_items
+      visit "/expressions/#{expression_items[0].expression.id}"
+    end
+
+    it 'check if the previous expression is on the page after deleting expression which is last id' do
+      delete_expression = Expression.find expression_items[0].expression.id
+      previous_expression = delete_expression.previous
+
+      accept_confirm do
+        click_button '削除'
+      end
+      expect(page).to have_content '英単語又はフレーズを削除しました'
+
+      previous_expression.expression_items.each do |expression_item|
+        within '.title' do
+          expect(page).to have_content expression_item.content
+        end
+      end
+    end
+  end
+
+  describe 'delete last expression in a list' do
+    it 'check if root page is on the screen when the last expression is deleted' do
+      visit '/'
+      click_link 'balcony and Veranda'
+      accept_confirm do
+        click_button '削除'
+      end
+      has_text? '英単語又はフレーズを削除しました'
+
+      expect(Expression.count).to eq 0
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content 'このリストに登録されている英単語またはフレーズはありません'
+    end
+  end
+end

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -3,13 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Expressions' do
-  before do
-    10.times do
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
-    end
-  end
-
   describe 'expressions/1' do
     it 'check url' do
       visit '/'
@@ -55,6 +48,11 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check the expression list after clicking the back button that goes to root path' do
+      10.times do
+        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+      end
+
       visit '/expressions/1'
       click_link '英単語・フレーズ一覧に戻る'
       expect(all('li').count).to eq 21
@@ -135,53 +133,6 @@ RSpec.describe 'Expressions' do
       within '.tag' do
         expect(page).to have_content 'タグ'
         expect(page).to have_content 'preposition'
-      end
-    end
-  end
-
-  describe 'delete expressions' do
-    before do
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      visit '/'
-      click_link 'balcony and Veranda'
-    end
-
-    it 'check if expression is deleted' do
-      expect do
-        click_button '削除'
-        expect(page.accept_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
-        expect(page).to have_content '英単語又はフレーズを削除しました'
-      end.to change(Expression, :count).by(-1).and change(ExpressionItem, :count).by(-2)
-
-      visit '/'
-      expect(page).not_to have_link 'balcony and Veranda'
-    end
-
-    it 'check if the expression is not deleted when cancel button is clicked' do
-      expect do
-        click_button '削除'
-        expect(page.dismiss_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
-        within '.title' do
-          expect(page).to have_content 'balcony'
-        end
-        click_link '英単語・フレーズ一覧に戻る'
-      end.to change(Expression, :count).by(0).and change(ExpressionItem, :count).by(0)
-
-      expect(page).to have_link 'balcony and Veranda'
-    end
-
-    it 'check if the next expression is on the page after deleting expression' do
-      delete_expression_item = ExpressionItem.find_by content: 'balcony'
-      next_expression = delete_expression_item.expression.next
-      accept_confirm do
-        click_button '削除'
-      end
-      expect(page).to have_content '英単語又はフレーズを削除しました'
-
-      next_expression.expression_items.each do |expression_item|
-        within '.title' do
-          expect(page).to have_content expression_item.content
-        end
       end
     end
   end


### PR DESCRIPTION
## Issue
- #63 

## Summary
リストに英単語・フレーズが保存されていないときの画面を作成した。
また、リストに登録されている最後の英単語・フレーズを削除したときにユーザーホームページに画面遷移するようにした。
リストに英単語・フレーズは登録されているが、削除した英単語・フレーズが最後のidであった場合は１つ前の英単語・フレーズを表示させるように実装した。