### PR TITLE
Create next and back button on details page

### DIFF
--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -38,6 +38,11 @@ p style="color: green" = notice
 div
   = link_to t('.edit'), edit_expression_path(@expression), data: { turbo: false }
   '|
-  = link_to t('.back'), root_path, data: { turbo: false }
+  = link_to t('.go_to_index'), root_path, data: { turbo: false }
 
   = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
+
+- if @expression.previous
+  = link_to t('.back'), expression_path(@expression.previous), data: { turbo: false }
+- if @expression.next
+  = link_to t('.next'), expression_path(@expression.next), data: { turbo: false }

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,10 +24,12 @@ ja:
       example: 例文
       note: メモ
       tag: タグ
-      back: 英単語・フレーズ一覧に戻る
+      go_to_index: 英単語・フレーズ一覧に戻る
       edit: 編集
       delete: 削除
       confirm_deletion_of_expression: この英単語又はフレーズを本当に削除しますか？
+      back: １つ前の英単語・フレーズへ
+      next: 次の英単語・フレーズへ
     edit:
       go_to_show: 詳細画面に戻る
       go_to_index: 英単語・フレーズ一覧に戻る

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -136,4 +136,46 @@ RSpec.describe 'Expressions' do
       end
     end
   end
+
+  describe 'next and back button' do
+    it 'check if there is no next button if the expression is the last one' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+      expect(page).to have_link '１つ前の英単語・フレーズへ', href: '/expressions/1'
+      expect(page).not_to have_link '次の英単語・フレーズへ'
+    end
+
+    it 'check if there is no back button if the expression is the first one' do
+      expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      visit '/expressions/1'
+      expect(page).to have_link '次の英単語・フレーズへ', href: "/expressions/#{expression_items[0].expression.id}"
+      expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+    end
+
+    it 'check if there is no back and next button when expression is one in a list' do
+      visit '/expressions/1'
+      expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+      expect(page).not_to have_link '次の英単語・フレーズへ'
+    end
+
+    it 'check next button' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+      click_link '次の英単語・フレーズへ'
+      expect(page).to have_current_path expression_path(second_expression_items[0].expression), ignore_query: true
+    end
+
+    it 'check back button' do
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+      visit "/expressions/#{second_expression_items[0].expression.id}"
+      click_link '１つ前の英単語・フレーズへ'
+      expect(page).to have_current_path expression_path(first_expression_items[0].expression), ignore_query: true
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #54 

## Summary
英単語・フレーズの詳細画面に`１つ前の英単語・フレーズへ`と`次の英単語・フレーズへ`ボタンを設置した。
また、英単語・フレーズを新規作成・削除・編集した際に、英単語・フレーズの詳細画面上に表示されるnoticeメッセージが、`１つ前の英単語・フレーズへ`と`次の英単語・フレーズへ`ボタンで画面遷移した際に再度表示されないようにした。