### PR TITLE
Make questions orders mix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Layout/LineLength:
     - "db/seeds.rb"
 
 RSpec/MultipleExpectations:
-  Max: 5
+  Max: 6
 
 RSpec/ExampleLength:
   Max: 11

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -62,7 +62,7 @@ export default {
       type: Number,
       required: true
     },
-    quizResources: {
+    rawQuizResources: {
       type: Array,
       required: true
     }
@@ -129,7 +129,7 @@ export default {
       listOfExpressionIds.forEach((id) => {
         const contents = []
 
-        const expression = this.quizResources.filter(
+        const expression = this.rawQuizResources.filter(
           (quizResource) => quizResource.expressionId === id
         )
         const lastIndex = expression.length - 1

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -158,7 +158,7 @@ export default {
       this.sortItems(this.listOfIncorrectItems)
     },
     sortItems(items) {
-      items.sort((first,second) => first.expressionId - second.expressionId)
+      items.sort((first, second) => first.expressionId - second.expressionId)
     }
   },
   mounted() {

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -154,6 +154,11 @@ export default {
           })
         }
       })
+      this.sortItems(this.listOfCorrectItems)
+      this.sortItems(this.listOfIncorrectItems)
+    },
+    sortItems(items) {
+      items.sort((first,second) => first.expressionId - second.expressionId)
     }
   },
   mounted() {

--- a/app/javascript/components/word-quiz.vue
+++ b/app/javascript/components/word-quiz.vue
@@ -4,7 +4,7 @@
       <WordQuizResult
         v-if="isResult"
         :number-of-quiz-resources="numberOfResources"
-        :quiz-resources="quizResources"
+        :raw-quiz-resources="rawQuizResources"
         :userAnswers="userAnswersList"></WordQuizResult>
       <div v-else>
         <p>{{ $t('quiz.question') }}</p>
@@ -58,6 +58,7 @@ export default {
       userAnswer: '',
       userAnswersList: [],
       quizResources: [],
+      rawQuizResources: [],
       numberOfResources: 0,
       currentIndex: 0,
       correctAnswer: '',
@@ -96,7 +97,9 @@ export default {
     setupQuiz() {
       this.fetchQuizResources().then((response) => {
         this.quizResources = response
+        this.rawQuizResources = response
         this.numberOfResources = this.quizResources.length
+        this.orderQuestions(this.numberOfResources)
       })
     },
     getCorrectAnswer() {
@@ -124,6 +127,18 @@ export default {
           expressionId: this.expressionId
         })
       }
+    },
+    orderQuestions(quizLength) {
+      const numbers = []
+      while (numbers.length < quizLength) {
+        const randomNumber = Math.floor(Math.random() * (quizLength - 0))
+        if (!numbers.includes(randomNumber)) numbers.push(randomNumber)
+      }
+      const orderedQuizResources = []
+      numbers.forEach((number) =>
+        orderedQuizResources.push(this.quizResources[number])
+      )
+      this.quizResources = orderedQuizResources
     }
   },
   mounted() {

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe 'Quiz' do
       end
     end
 
-    context 'when one expression is in bookmark list and one expression is in memorised words list' do
+    context 'when one expression is in the list that go to bookmark and one expression is in the list that go to memorised words list' do
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
       let(:answers) { [] } # クイズの問題がランダムに出題されるため、クイズで入力した値をexampleで取得できるようにbeforeでこの配列に値を代入
 

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -261,8 +261,9 @@ RSpec.describe 'Quiz' do
         expect(all('ul.list-of-correct-answers li').count).to eq 0
 
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
-        expect(page).to have_content 'balcony and Veranda'
-        expect(page).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+
+        expect(first('ul.list-of-correct-answers li')).to have_content 'balcony and Veranda'
+        expect(all('ul.list-of-correct-answers li')[1]).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         expect(all('ul.list-of-incorrect-answers li').count).to eq 0
@@ -291,8 +292,8 @@ RSpec.describe 'Quiz' do
         expect(all('ul.list-of-incorrect-answers li').count).to eq 0
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
-        expect(page).to have_content 'balcony and Veranda'
-        expect(page).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+        expect(first('ul.list-of-incorrect-answers li')).to have_content 'balcony and Veranda'
+        expect(all('ul.list-of-incorrect-answers li')[1]).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
 
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         expect(all('ul.list-of-correct-answers li').count).to eq 0

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -9,15 +9,28 @@ RSpec.describe 'Quiz' do
     end
 
     it 'check if one question and no answer is on the question screen' do
-      expect(page).to have_content 'A platform on the side of a building, accessible from inside the building.'
-      expect(page).not_to have_content 'A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy'
-      expect(page).not_to have_content 'balcony'
+      if has_text?('A platform on the side of a building, accessible from inside the building.')
+        expect(page).to have_content 'A platform on the side of a building, accessible from inside the building.'
+        expect(page).not_to have_content 'A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy'
+        expect(page).not_to have_content 'balcony'
+      else
+        expect(page).to have_content(
+          'A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.'
+        )
+        expect(page).not_to have_content 'A platform on the side of a building, accessible from inside the building.'
+        expect(page).not_to have_content 'Veranda'
+      end
     end
 
     it 'check if the correct answer is judged as right one' do
-      fill_in('解答を入力', with: 'balcony')
+      if has_text?('A platform on the side of a building, accessible from inside the building.')
+        fill_in('解答を入力', with: 'balcony')
+      else
+        fill_in('解答を入力', with: 'Veranda')
+      end
       click_button 'クイズに解答する'
       expect(page).to have_content '◯ 正解!'
+      expect(page).not_to have_content '×不正解'
     end
 
     it 'check if the incorrect answer is judged as wrong one' do
@@ -48,7 +61,7 @@ RSpec.describe 'Quiz' do
   end
 
   describe 'quiz result' do
-    describe 'quiz result that questions were two' do
+    describe 'check if screens change' do
       before do
         visit '/quiz'
       end
@@ -65,45 +78,6 @@ RSpec.describe 'Quiz' do
         expect(page).to have_content 'クイズお疲れ様でした！'
       end
 
-      it 'show user answers list' do
-        fill_in('解答を入力', with: 'Balcony')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'wrong answer')
-        click_button 'クイズに解答する'
-        click_button 'クイズの結果を確認する'
-
-        find('summary', text: '自分の解答を表示').click
-        expect(page).to have_content '◯ Balcony'
-        expect(page).to have_content '× wrong answer'
-      end
-
-      it 'show 未入力 if the user answer is blank' do
-        fill_in('解答を入力', with: '')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'veranda')
-        click_button 'クイズに解答する'
-        click_button 'クイズの結果を確認する'
-
-        find('summary', text: '自分の解答を表示').click
-        expect(page).to have_content '× 未入力'
-      end
-
-      it 'show important notice with red text color' do
-        fill_in('解答を入力', with: '')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'veranda')
-        click_button 'クイズに解答する'
-        click_button 'クイズの結果を確認する'
-
-        expect(page).to have_selector(
-          '.text-red-600',
-          text: '重要: 一度この画面を離れると戻れません。今回の結果をブックマークや覚えたリストに移動させる場合は、下記ボタンをクリックする前に必ず行なってください。'
-        )
-      end
-
       it 'show new quiz' do
         fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
@@ -118,13 +92,75 @@ RSpec.describe 'Quiz' do
       end
     end
 
-    describe 'quiz result that questions were six' do
+    describe 'show user answers when one answer is correct and one answer is incorrect' do
+      let(:answers) { [] } # クイズの問題がランダムに出題されるため、クイズで入力した値をexampleで取得できるようにbeforeでこの配列に値を代入
+
       before do
-        2.times { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
         visit '/quiz'
+        fill_in('解答を入力', with: 'wrong answer')
+        click_button 'クイズに解答する'
+        click_button '次へ'
+        if has_text?('A platform on the side of a building, accessible from inside the building.')
+          fill_in('解答を入力', with: 'Balcony')
+          answers.push 'Balcony'
+        else
+          fill_in('解答を入力', with: 'veranda')
+          answers.push 'veranda'
+        end
+        click_button 'クイズに解答する'
+        click_button 'クイズの結果を確認する'
       end
 
-      it 'check if the right number of user answers are on the page when 自分の解答を表示 is clicked' do
+      it 'check user answers list' do
+        find('summary', text: '自分の解答を表示').click
+
+        expect(page).to have_content '× wrong answer'
+        expect(page).to have_content('◯ Balcony') if answers[0] == 'Balcony'
+        expect(page).to have_content('◯ veranda') if answers[0] == 'veranda'
+      end
+    end
+
+    describe 'show user answers when an answer was not given' do
+      before do
+        visit '/quiz'
+        fill_in('解答を入力', with: '')
+        click_button 'クイズに解答する'
+        click_button '次へ'
+        fill_in('解答を入力', with: 'veranda')
+        click_button 'クイズに解答する'
+        click_button 'クイズの結果を確認する'
+      end
+
+      it 'show 未入力 if the user answer is blank' do
+        find('summary', text: '自分の解答を表示').click
+        expect(page).to have_content '× 未入力'
+      end
+    end
+
+    describe 'show important notice' do
+      before do
+        visit '/quiz'
+        fill_in('解答を入力', with: '')
+        click_button 'クイズに解答する'
+        click_button '次へ'
+        fill_in('解答を入力', with: 'veranda')
+        click_button 'クイズに解答する'
+        click_button 'クイズの結果を確認する'
+      end
+
+      it 'show important notice with red text color' do
+        expect(page).to have_selector(
+          '.text-red-600',
+          text: '重要: 一度この画面を離れると戻れません。今回の結果をブックマークや覚えたリストに移動させる場合は、下記ボタンをクリックする前に必ず行なってください。'
+        )
+      end
+    end
+
+    describe 'show user answers when questions were six' do
+      before do
+        2.times { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+
+        visit '/quiz'
         5.times do
           fill_in('解答を入力', with: 'test')
           click_button 'クイズに解答する'
@@ -133,61 +169,133 @@ RSpec.describe 'Quiz' do
         fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         click_button 'クイズの結果を確認する'
+      end
 
+      it 'check if the right number of user answers are on the page when 自分の解答を表示 is clicked' do
         find('summary', text: '自分の解答を表示').click
         expect(all('ul.user-answer-list li').count).to eq 6
       end
     end
 
-    describe 'lists that contain words and phrases that go to bookmark or memorised words list' do
+    context 'when one expression is in bookmark list and one expression is in memorised words list' do
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+      let(:answers) { [] } # クイズの問題がランダムに出題されるため、クイズで入力した値をexampleで取得できるようにbeforeでこの配列に値を代入
 
       before do
         visit '/quiz'
-        fill_in('解答を入力', with: 'balcony')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'veranda')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: first_expression_items[0].content)
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'wrong answer')
-        click_button 'クイズに解答する'
-        click_button '次へ'
-        fill_in('解答を入力', with: 'wrong answer')
-        click_button 'クイズに解答する'
-        click_button '次へ'
         fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         click_button '次へ'
-        fill_in('解答を入力', with: '')
-        click_button 'クイズに解答する'
-        click_button 'クイズの結果を確認する'
+        3.times do |n|
+          if has_text?('A platform on the side of a building, accessible from inside the building.')
+            fill_in('解答を入力', with: 'balcony')
+            answers.push('balcony')
+          elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
+            fill_in('解答を入力', with: 'veranda')
+            answers.push('veranda')
+          elsif has_text?(first_expression_items[0].explanation)
+            fill_in('解答を入力', with: first_expression_items[0].content)
+          elsif has_text?(first_expression_items[1].explanation)
+            fill_in('解答を入力', with: first_expression_items[1].content)
+          end
+
+          click_button 'クイズに解答する'
+          n < 2 ? click_button('次へ') : click_button('クイズの結果を確認する')
+        end
       end
 
-      it 'check if balcony and veranda is in the list that goes to memorised words list' do
-        expect(page).not_to have_content 'balcony and Veranda'
+      it 'check if one expression is in the list that goes to memorised words list' do
+        expect(all('ul.list-of-correct-answers li').count).to eq 0
 
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
-        expect(page).to have_content 'balcony and Veranda'
-        expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
-        expect(page).not_to have_content(
-          "#{second_expression_items[0].content}, #{second_expression_items[1].content} and #{second_expression_items[2].content}"
-        )
+        if answers.count == 2
+          expect(page).to have_content 'balcony and Veranda'
+          expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        else
+          expect(page).to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).not_to have_content 'balcony and Veranda'
+        end
+
         expect(all('ul.list-of-correct-answers li').count).to eq 1
       end
 
-      it 'check if wrong answers are in the list that go to bookmark' do
+      it 'check if one expression is in the list that go to bookmark' do
         expect(all('ul.list-of-incorrect-answers li').count).to eq 0
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
-        expect(page).to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
-        expect(page).to have_content "#{second_expression_items[0].content}, #{second_expression_items[1].content} and #{second_expression_items[2].content}"
-        expect(page).not_to have_content 'balcony and Veranda'
-        expect(all('ul.list-of-incorrect-answers li').count).to eq 2
+        if answers.count == 2
+          expect(page).to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).not_to have_content 'balcony and Veranda'
+        else
+          expect(page).to have_content 'balcony and Veranda'
+          expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        end
+
+        expect(all('ul.list-of-incorrect-answers li').count).to eq 1
+      end
+    end
+
+    context 'when two expressions are in memorised words list and zero expression is in bookmark list' do
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+
+      before do
+        visit '/quiz'
+        5.times do |n|
+          if has_text?('A platform on the side of a building, accessible from inside the building.')
+            fill_in('解答を入力', with: 'balcony')
+          elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
+            fill_in('解答を入力', with: 'veranda')
+          elsif has_text?(first_expression_items[0].explanation)
+            fill_in('解答を入力', with: first_expression_items[0].content)
+          elsif has_text?(first_expression_items[1].explanation)
+            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_items[2].explanation)
+            fill_in('解答を入力', with: first_expression_items[2].content)
+          end
+          click_button 'クイズに解答する'
+          n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+        end
+      end
+
+      it 'check if memorised words list has two expressions' do
+        expect(all('ul.list-of-correct-answers li').count).to eq 0
+
+        find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
+        expect(page).to have_content 'balcony and Veranda'
+        expect(page).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+
+        find('summary', text: 'ブックマークする英単語・フレーズ').click
+        expect(all('ul.list-of-incorrect-answers li').count).to eq 0
+      end
+    end
+
+    context 'when two expressions are in bookmark list and zero expression is in memorised words list' do
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+
+      before do
+        visit '/quiz'
+        2.times do
+          fill_in('解答を入力', with: 'wrong answer')
+          click_button 'クイズに解答する'
+          click_button '次へ'
+          fill_in('解答を入力', with: '')
+          click_button 'クイズに解答する'
+          click_button('次へ')
+        end
+        fill_in('解答を入力', with: '')
+        click_button 'クイズに解答する'
+        click_button('クイズの結果を確認する')
+      end
+
+      it 'check if bookmark list has two expressions' do
+        expect(all('ul.list-of-incorrect-answers li').count).to eq 0
+
+        find('summary', text: 'ブックマークする英単語・フレーズ').click
+        expect(page).to have_content 'balcony and Veranda'
+        expect(page).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+
+        find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
+        expect(all('ul.list-of-correct-answers li').count).to eq 0
       end
     end
   end

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -263,7 +263,9 @@ RSpec.describe 'Quiz' do
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
 
         expect(first('ul.list-of-correct-answers li')).to have_content 'balcony and Veranda'
-        expect(all('ul.list-of-correct-answers li')[1]).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+        expect(all('ul.list-of-correct-answers li')[1]).to have_content(
+          "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+        )
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         expect(all('ul.list-of-incorrect-answers li').count).to eq 0
@@ -293,7 +295,9 @@ RSpec.describe 'Quiz' do
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         expect(first('ul.list-of-incorrect-answers li')).to have_content 'balcony and Veranda'
-        expect(all('ul.list-of-incorrect-answers li')[1]).to have_content "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+        expect(all('ul.list-of-incorrect-answers li')[1]).to have_content(
+          "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+        )
 
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         expect(all('ul.list-of-correct-answers li').count).to eq 0


### PR DESCRIPTION
## Issue
- #50 

## Summary
クイズで出題される問題の出題される順番をランダムにした。
それによってクイズの最終結果表示ページに表示される、ブックマークされる予定の英単語・フレーズのリストと覚えたリストに移動する予定の英単語・フレーズのリストの中身の並び順が問題の出題された順に変わってしまったので、この並び順を英単語・フレーズが作成された順に並ぶように修正した。