### PR TITLE
Add right answer to user answer that is incorrect and in user answers list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Layout/LineLength:
   Exclude:
     - "db/seeds.rb"
 
+Style/CaseLikeIf:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Max: 6
 

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -35,10 +35,16 @@
     <summary>{{ $t('quiz.result.showUserAnswers') }}</summary>
     <ul class="user-answer-list">
       <template v-for="userAnswer in userAnswers" :key="userAnswer">
-        <li v-if="userAnswer.content === '× '">
+        <li v-if="userAnswer.content[0] === '× '">
           × {{ $t('quiz.result.blank') }}
+          {{ userAnswer.content[1] }}
         </li>
-        <li v-else>{{ userAnswer.content }}</li>
+        <li v-else>
+          {{ userAnswer.content[0] }}
+          <div v-if="userAnswer.content[1]" class="inline">
+            {{ userAnswer.content[1] }}
+          </div>
+        </li>
       </template>
     </ul>
   </details>
@@ -86,7 +92,7 @@ export default {
     },
     getNumberOfCorrectAnswers() {
       const correctAnswers = this.userAnswers.filter((userAnswer) =>
-        userAnswer.content.match(/^◯.+/g)
+        userAnswer.content[0].match(/^◯.+/g)
       )
       this.numberOfCorrectAnswers = correctAnswers.length
     },
@@ -116,7 +122,7 @@ export default {
     classifyExpressionGroupsByRightOrWrong() {
       this.expressionGroups.forEach((expressionGroup) => {
         const correctAnswers = expressionGroup.filter((element) =>
-          element.content.match(/^◯.+/g)
+          element.content[0].match(/^◯.+/g)
         )
         if (correctAnswers.length === expressionGroup.length) {
           this.allCorrectExpressionIds.push(expressionGroup[0].expressionId)

--- a/app/javascript/components/word-quiz.vue
+++ b/app/javascript/components/word-quiz.vue
@@ -118,12 +118,15 @@ export default {
     createUserAnswersList() {
       if (this.isCorrect) {
         this.userAnswersList.push({
-          content: `◯ ${this.userAnswer}`,
+          content: [`◯ ${this.userAnswer}`],
           expressionId: this.expressionId
         })
       } else {
         this.userAnswersList.push({
-          content: `× ${this.userAnswer}`,
+          content: [
+            `× ${this.userAnswer}`,
+            `( Answer: ${this.correctAnswer} )`
+          ],
           expressionId: this.expressionId
         })
       }

--- a/app/javascript/locales/ja.json
+++ b/app/javascript/locales/ja.json
@@ -14,7 +14,7 @@
         "result": {
             "wellDone": "クイズお疲れ様でした！",
             "showUserAnswers": "自分の解答を表示",
-            "blank": "未入力",
+            "blank": "無解答",
             "numberOfCorrectAnswers": "{totalQuestions}問中{numberOfCorrectAnswers}問正解です",
             "bookmark": "不正解だった英単語又はフレーズと、それと一緒に保存されている英単語・フレーズを全てブックマークする",
             "bookmarkList": "ブックマークする英単語・フレーズ",

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -114,9 +114,13 @@ RSpec.describe 'Quiz' do
       it 'check user answers list' do
         find('summary', text: '自分の解答を表示').click
 
-        expect(page).to have_content '× wrong answer'
-        expect(page).to have_content('◯ Balcony') if answers[0] == 'Balcony'
-        expect(page).to have_content('◯ veranda') if answers[0] == 'veranda'
+        if answers[0] == 'Balcony'
+          expect(page).to have_content '× wrong answer ( Answer: Veranda )'
+          expect(page).to have_content('◯ Balcony')
+        elsif answers[0] == 'veranda'
+          expect(page).to have_content '× wrong answer ( Answer: balcony )'
+          expect(page).to have_content('◯ veranda')
+        end
       end
     end
 
@@ -126,14 +130,15 @@ RSpec.describe 'Quiz' do
         fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         click_button '次へ'
-        fill_in('解答を入力', with: 'veranda')
+        fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         click_button 'クイズの結果を確認する'
       end
 
-      it 'show 未入力 if the user answer is blank' do
+      it 'show 無解答 if the user answer is blank' do
         find('summary', text: '自分の解答を表示').click
-        expect(page).to have_content '× 未入力'
+        expect(page).to have_content '× 無解答 ( Answer: balcony )'
+        expect(page).to have_content '× 無解答 ( Answer: Veranda )'
       end
     end
 


### PR DESCRIPTION
## Issue
- #111 

## Summary
クイズ終了後に表示される最終結果画面のユーザーの解答一覧の内容が、間違った問題に対する答えが表示されている場合、どの問題に対する答えだったのかが分からなかったので、ユーザーの間違った解答と無解答には、加えて正解も表示させるようにした。