### PR TITLE
Create the function of saving expressions to memorised words list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,4 +16,4 @@ RSpec/MultipleExpectations:
   Max: 6
 
 RSpec/ExampleLength:
-  Max: 11
+  Max: 13

--- a/app/controllers/api/bookmarkings_controller.rb
+++ b/app/controllers/api/bookmarkings_controller.rb
@@ -3,7 +3,7 @@
 class Api::BookmarkingsController < ApplicationController
   def create
     if logged_in?
-      Bookmarking.create_all!(current_user.id, bookmarking_params[:expression_id])
+      Bookmarking.create_bookmarkings_or_memorisings!(current_user.id, bookmarking_params[:expression_id])
       head :no_content
     else
       head :unauthorized

--- a/app/controllers/api/memorisings_controller.rb
+++ b/app/controllers/api/memorisings_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class Api::BookmarkingsController < ApplicationController
+class Api::MemorisingsController < ApplicationController
   def create
     if logged_in?
-      result = Bookmarking.create_bookmarkings_or_memorisings!(current_user.id, bookmarking_params[:expression_id])
+      result = Memorising.create_bookmarkings_or_memorisings!(current_user.id, memorising_params[:expression_id])
 
       if result == 'failure'
         head :unprocessable_entity
@@ -19,7 +19,7 @@ class Api::BookmarkingsController < ApplicationController
 
   private
 
-  def bookmarking_params
-    params.require(:bookmarking).permit(expression_id: [])
+  def memorising_params
+    params.require(:memorising).permit(expression_id: [])
   end
 end

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -12,7 +12,7 @@
   </div>
   <div v-if="!isSaved" class="move-to-bookmark-or-memorised-list pb-8">
     <div
-      v-if="listOfWrongItems.length > 0"
+      v-if="listOfWrongItems.length > 0 && !isSavedBookmark"
       class="section-of-wrong-answers py-2.5">
       <input
         type="checkbox"
@@ -36,7 +36,7 @@
       </details>
     </div>
     <div
-      v-if="listOfCorrectItems.length > 0"
+      v-if="listOfCorrectItems.length > 0 && !isSavedMemorisedList"
       class="section-of-correct-answers py-2.5">
       <input
         type="checkbox"
@@ -122,7 +122,12 @@ export default {
       isCheckedAllToBookmark: true,
       isCheckedAllToMemorisedList: true,
       isSaved: false,
-      toast: useToast()
+      isSavedBookmark: false,
+      isSavedMemorisedList: false,
+      toast: useToast(),
+      success: [],
+      warning: false,
+      failure: []
     }
   },
   methods: {
@@ -130,8 +135,9 @@ export default {
       const meta = document.querySelector('meta[name="csrf-token"]')
       return meta ? meta.getAttribute('content') : ''
     },
-    createBookmarks() {
-      fetch('/api/bookmarked_expressions', {
+    async createBookmarksOrMemorisedList(path, expressionIds) {
+      const url = `/api/${path}_expressions`
+      const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json; charset=utf-8',
@@ -140,24 +146,121 @@ export default {
         },
         credentials: 'same-origin',
         redirect: 'manual',
-        body: JSON.stringify({ expression_id: this.checkedContentsToBookmark })
+        body: JSON.stringify({ expression_id: expressionIds })
       })
-        .then((response) => {
-          if (response.status === 204) {
-            this.isSaved = true
-            this.toast.success('ブックマークしました！')
-          } else if (response.status === 401) {
-            //  ログインしていないためブックマークできない時の処理をここに書く
-          } else {
-            this.toast.error('ブックマークできませんでした')
-          }
-        })
-        .catch((e) => {
-          console.warn(e)
-        })
+      return response
     },
-    save() {
-      this.createBookmarks()
+    showToast() {
+      const warning = this.createWarning()
+      if (this.success[0] === 'bookmarked_expressions') {
+        this.toast.success(`ブックマークしました！${warning}`)
+      } else if (this.success[0] === 'memorised_expressions') {
+        this.toast.success(
+          `英単語・フレーズを覚えた語彙リストに保存しました！${warning}`
+        )
+      } else if (this.failure[0] === 'bookmarked_expressions') {
+        this.toast.error('ブックマークできませんでした')
+      } else if (this.failure[0] === 'memorised_expressions') {
+        this.toast.error(
+          '覚えた語彙リストに英単語・フレーズを保存できませんでした'
+        )
+      }
+    },
+    checkResponse(response) {
+      const bookmark = response.url.match(/bookmarked_expressions$/g)
+      const memorisedList = response.url.match(/memorised_expressions$/g)
+      const bookmarkOrMemorisedList = bookmark || memorisedList
+      if (response.status === 204) {
+        this.success.push(...bookmarkOrMemorisedList)
+      } else if (response.status === 201) {
+        this.success.push(...bookmarkOrMemorisedList)
+        this.warning = true
+      } else if (response.status === 401) {
+        //  ログインしていないためブックマークできない時の処理をここに書く
+      } else {
+        this.failure.push(...bookmarkOrMemorisedList)
+      }
+    },
+    resetCheckResponse() {
+      this.success = []
+      this.failure = []
+      this.warning = false
+    },
+    createWarning() {
+      return this.warning
+        ? '\n(存在が確認できなかった英単語・フレーズを除く)'
+        : ''
+    },
+    async save() {
+      if (
+        this.checkedContentsToBookmark.length > 0 &&
+        this.checkedContentsToMemorisedList.length > 0
+      ) {
+        Promise.all([
+          this.createBookmarksOrMemorisedList(
+            'bookmarked',
+            this.checkedContentsToBookmark
+          ),
+          this.createBookmarksOrMemorisedList(
+            'memorised',
+            this.checkedContentsToMemorisedList
+          )
+        ]).then((responses) => {
+          responses.forEach((response) => {
+            this.checkResponse(response)
+          })
+          const warning = this.createWarning()
+          if (this.failure.length === 2) {
+            this.toast.error(
+              'ブックマーク・覚えた語彙リストに英単語・フレーズを保存できませんでした'
+            )
+          } else if (this.success.length === 2) {
+            this.isSaved = true
+            this.toast.success(
+              `ブックマーク・覚えた語彙リストに英単語・フレーズを保存しました！${warning}`
+            )
+          } else if (
+            this.failure[0] === 'bookmarked_expressions' &&
+            this.success[0] === 'memorised_expressions'
+          ) {
+            this.isSavedMemorisedList = true
+            this.checkedContentsToMemorisedList = []
+            this.toast.warning(
+              `覚えた語彙リストに英単語・フレーズを保存しました${warning}がブックマークは出来ませんでした`
+            )
+          } else if (
+            this.failure[0] === 'memorised_expressions' &&
+            this.success[0] === 'bookmarked_expressions'
+          ) {
+            this.isSavedBookmark = true
+            this.checkedContentsToBookmark = []
+            this.toast.warning(
+              `英単語・フレーズをブックマークしました${warning}が覚えた語彙リストには保存できませんでした`
+            )
+          }
+          this.resetCheckResponse()
+        })
+      } else if (this.checkedContentsToBookmark.length > 0) {
+        this.createBookmarksOrMemorisedList(
+          'bookmarked',
+          this.checkedContentsToBookmark
+        ).then((response) => {
+          this.checkResponse(response)
+          if (this.success.length > 0) this.isSaved = true
+          this.showToast()
+          this.resetCheckResponse()
+        })
+      } else if (this.checkedContentsToMemorisedList.length > 0) {
+        this.createBookmarksOrMemorisedList(
+          'memorised',
+          this.checkedContentsToMemorisedList
+        ).then((response) => {
+          this.checkResponse(response)
+          if (this.success.length > 0) this.isSaved = true
+          this.showToast()
+          this.resetCheckResponse()
+        })
+      }
     },
     isCheckedAll(type) {
       if (type === 'bookmark') {

--- a/app/models/bookmarking.rb
+++ b/app/models/bookmarking.rb
@@ -5,4 +5,6 @@ class Bookmarking < ApplicationRecord
 
   belongs_to :user
   belongs_to :expression
+
+  validates :user_id, uniqueness: { scope: :expression_id }
 end

--- a/app/models/bookmarking.rb
+++ b/app/models/bookmarking.rb
@@ -1,25 +1,8 @@
 # frozen_string_literal: true
 
 class Bookmarking < ApplicationRecord
+  extend Recordable
+
   belongs_to :user
   belongs_to :expression
-
-  def self.create_all!(user_id, expression_ids)
-    bookmarkings = []
-
-    expression_ids.each do |expression_id|
-      next if Bookmarking.exists?(user_id:, expression_id:)
-
-      bookmarking = Bookmarking.new
-      bookmarking.user_id = user_id
-      bookmarking.expression_id = expression_id
-      bookmarkings.push(bookmarking)
-    end
-
-    return unless bookmarkings.count.positive?
-
-    Bookmarking.transaction do
-      bookmarkings.each(&:save!)
-    end
-  end
 end

--- a/app/models/concerns/recordable.rb
+++ b/app/models/concerns/recordable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Recordable
+  def create_bookmarkings_or_memorisings!(user_id, expression_ids)
+    exist_expression_ids = expression_ids.select { |expression_id| Expression.exists?(id: expression_id) }
+    return 'failure' if exist_expression_ids.count.zero?
+
+    transaction do
+      exist_expression_ids.each do |expression_id|
+        object = new
+        object.user_id = user_id
+        object.expression_id = expression_id
+        object.save!
+      end
+    end
+
+    expression_ids.count == exist_expression_ids.count
+  end
+end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -6,6 +6,8 @@ class Expression < ApplicationRecord
   has_many :tags, through: :taggings
   has_many :bookmarkings, dependent: :destroy
   has_many :users, through: :bookmarkings
+  has_many :memorisings, dependent: :destroy
+  has_many :users, through: :memorisings
   accepts_nested_attributes_for :expression_items, reject_if: lambda { |attributes|
     attributes['content'].blank?
   }

--- a/app/models/memorising.rb
+++ b/app/models/memorising.rb
@@ -3,4 +3,6 @@
 class Memorising < ApplicationRecord
   belongs_to :user
   belongs_to :expression
+
+  validates :user_id, uniqueness: { scope: :expression_id }
 end

--- a/app/models/memorising.rb
+++ b/app/models/memorising.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Memorising < ApplicationRecord
+  extend Recordable
+
   belongs_to :user
   belongs_to :expression
 

--- a/app/models/memorising.rb
+++ b/app/models/memorising.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Memorising < ApplicationRecord
+  belongs_to :user
+  belongs_to :expression
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 class User < ApplicationRecord
   has_many :bookmarkings, dependent: :destroy
   has_many :expressions, through: :bookmarkings
+  has_many :memorisings, dependent: :destroy
+  has_many :expressions, through: :memorisings
 
   def self.find_or_create_from_auth_hash!(auth_hash)
     uid = auth_hash[:uid]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
     resources :expressions, only: [:index, :edit]
     resource :quiz, only: [:show]
     post '/bookmarked_expressions', to: 'bookmarkings#create'
+    post '/memorised_expressions', to: 'memorisings#create'
   end
 end

--- a/db/migrate/20230425142334_create_memorisings.rb
+++ b/db/migrate/20230425142334_create_memorisings.rb
@@ -1,0 +1,10 @@
+class CreateMemorisings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :memorisings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :expression, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230428084541_add_index_to_memorisings.rb
+++ b/db/migrate/20230428084541_add_index_to_memorisings.rb
@@ -1,0 +1,6 @@
+class AddIndexToMemorisings < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :memorisings, :user_id
+    add_index :memorisings, [:user_id, :expression_id], unique: true
+  end
+end

--- a/db/migrate/20230428160920_add_index_to_bookmarkings.rb
+++ b/db/migrate/20230428160920_add_index_to_bookmarkings.rb
@@ -1,0 +1,6 @@
+class AddIndexToBookmarkings < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :bookmarkings, :user_id
+    add_index :bookmarkings, [:user_id, :expression_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_20_034851) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_142334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_034851) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "memorisings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "expression_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expression_id"], name: "index_memorisings_on_expression_id"
+    t.index ["user_id"], name: "index_memorisings_on_user_id"
+  end
+
   create_table "taggings", force: :cascade do |t|
     t.bigint "expression_id", null: false
     t.bigint "tag_id", null: false
@@ -72,6 +81,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_20_034851) do
   add_foreign_key "bookmarkings", "users"
   add_foreign_key "examples", "expression_items"
   add_foreign_key "expression_items", "expressions"
+  add_foreign_key "memorisings", "expressions"
+  add_foreign_key "memorisings", "users"
   add_foreign_key "taggings", "expressions"
   add_foreign_key "taggings", "tags"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_142334) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_28_084541) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_142334) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["expression_id"], name: "index_memorisings_on_expression_id"
-    t.index ["user_id"], name: "index_memorisings_on_user_id"
+    t.index ["user_id", "expression_id"], name: "index_memorisings_on_user_id_and_expression_id", unique: true
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_28_084541) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_28_160920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_28_084541) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["expression_id"], name: "index_bookmarkings_on_expression_id"
-    t.index ["user_id"], name: "index_bookmarkings_on_user_id"
+    t.index ["user_id", "expression_id"], name: "index_bookmarkings_on_user_id_and_expression_id", unique: true
   end
 
   create_table "examples", force: :cascade do |t|

--- a/spec/factories/memorisings.rb
+++ b/spec/factories/memorisings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :memorising do
+    user
+    association :expression, factory: :empty_note
+  end
+end

--- a/spec/models/bookmarking_spec.rb
+++ b/spec/models/bookmarking_spec.rb
@@ -3,20 +3,5 @@
 require 'rails_helper'
 
 RSpec.describe Bookmarking, type: :model do
-  let!(:user) { FactoryBot.create(:user) }
-  let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-  let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-  let!(:bookmarking) { FactoryBot.create(:bookmarking) }
-
-  describe '.create_all!' do
-    it 'create bookmarkings' do
-      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
-      expect { described_class.create_all!(user.id, expression_ids) }.to change(described_class, :count).by(2)
-    end
-
-    it 'create one bookmarking but not the one that already exists' do
-      expression_ids = [bookmarking.expression_id, first_expression_items[0].expression_id]
-      expect { described_class.create_all!(bookmarking.user_id, expression_ids) }.to change(described_class, :count).by(1)
-    end
-  end
+  pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/bookmarking_spec.rb
+++ b/spec/models/bookmarking_spec.rb
@@ -3,5 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Bookmarking, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validation' do
+    it 'bookmarking cannot be saved if same record exists' do
+      user = FactoryBot.create(:user)
+      expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+      new_memorising = described_class.new(user_id: user.id, expression_id: expression_items[0].expression.id)
+      expect(new_memorising).to be_valid
+
+      bookmarking = FactoryBot.create(:bookmarking)
+      same_bookmarking = described_class.new(user_id: bookmarking.user_id, expression_id: bookmarking.expression_id)
+      expect(same_bookmarking).not_to be_valid
+    end
+  end
 end

--- a/spec/models/concerns/recordable_spec.rb
+++ b/spec/models/concerns/recordable_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Recordable, type: :model do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+  let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+
+  describe '.create_bookmarkings_or_memorisings!' do
+    it 'create bookmarkings' do
+      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
+      expect { Bookmarking.create_bookmarkings_or_memorisings!(user.id, expression_ids) }.to change(Bookmarking, :count).by(2)
+    end
+
+    it 'create memorisings' do
+      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
+      expect { Memorising.create_bookmarkings_or_memorisings!(user.id, expression_ids) }.to change(Memorising, :count).by(2)
+    end
+
+    it 'return true' do
+      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
+      expect(Bookmarking.create_bookmarkings_or_memorisings!(user.id, expression_ids)).to be true
+    end
+
+    it 'return false' do
+      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
+      first_expression_items[0].expression.destroy
+      expect(Bookmarking.create_bookmarkings_or_memorisings!(user.id, expression_ids)).to be false
+    end
+
+    it 'return failure' do
+      expression_ids = [first_expression_items[0].expression_id, second_expression_items[0].expression_id]
+      first_expression_items[0].expression.destroy
+      second_expression_items[0].expression.destroy
+      expect(Bookmarking.create_bookmarkings_or_memorisings!(user.id, expression_ids)).to eq 'failure'
+    end
+  end
+end

--- a/spec/models/memorising_spec.rb
+++ b/spec/models/memorising_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Memorising, type: :model do
+  describe 'validation' do
+    it 'memorising cannot be saved if same record exists' do
+      user = FactoryBot.create(:user)
+      expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+      new_memorising = described_class.new(user_id: user.id, expression_id: expression_items[0].expression.id)
+      expect(new_memorising).to be_valid
+
+      memorising = FactoryBot.create(:memorising)
+      same_memorising = described_class.new(user_id: memorising.user_id, expression_id: memorising.expression_id)
+      expect(same_memorising).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #40 
- #45 

## Summary
クイズに正解した英単語・フレーズ（共に保存されている英単語・フレーズも正解した場合のみ）を覚えた語彙リストに移動させる機能を実装した。それに伴い、ブックマークの機能も修正が必要だったのでコードの変更を加えた。