### PR TITLE
Create list of memorised words

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,4 +16,4 @@ RSpec/MultipleExpectations:
   Max: 6
 
 RSpec/ExampleLength:
-  Max: 13
+  Max: 14

--- a/app/controllers/api/memorisings_controller.rb
+++ b/app/controllers/api/memorisings_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Api::MemorisingsController < ApplicationController
+  def index
+    @memorisings = current_user.memorisings
+  end
+
   def create
     if logged_in?
       result = Memorising.create_bookmarkings_or_memorisings!(current_user.id, memorising_params[:expression_id])

--- a/app/controllers/memorised_expressions_controller.rb
+++ b/app/controllers/memorised_expressions_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MemorisedExpressionsController < ApplicationController
+  def index
+    @memorisings = current_user.memorisings if logged_in?
+  end
+end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -42,8 +42,9 @@ class Expression < ApplicationRecord
 
     Expression.where('user_id = ?', user_id).order(:created_at).each do |expression|
       bookmarked_expression = Bookmarking.find_by(expression_id: expression.id)
+      memorised_expression = Memorising.find_by(expression_id: expression.id)
 
-      unless bookmarked_expression
+      if !bookmarked_expression && !memorised_expression
         expression = Expression.find expression.id
         expressions.push expression
       end

--- a/app/views/api/memorisings/index.json.jbuilder
+++ b/app/views/api/memorisings/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.array! @memorisings do |memorising|
+  json.id memorising.expression_id
+  json.tags memorising.expression.tags.pluck(:name)# インクリメントサーチでタグの検索ために記載
+  json.expression_items do
+    json.array! memorising.expression.expression_items do |expression_item|
+      json.expression expression_item.content
+    end
+  end
+end

--- a/app/views/memorised_expressions/index.html.slim
+++ b/app/views/memorised_expressions/index.html.slim
@@ -1,0 +1,9 @@
+- if @memorisings.blank?
+  - if logged_in?
+    p
+      = t('.no_data')
+  - else
+    p
+      = t('.unauthorized')
+- else
+  div(data-vue='ExpressionsList' data-vue-path='api/memorised_expressions')

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,10 @@ ja:
     index:
       no_data: ブックマークしている英単語またはフレーズはありません
       unauthorized: ログインしていないため閲覧できません
+  memorised_expressions:
+    index:
+      no_data: 覚えた語彙リストに登録している英単語またはフレーズはありません
+      unauthorized: ログインしていないため閲覧できません
   users:
     confirm_deletion_of_account: "アカウントを削除しますか？\n \n重要:アカウントを削除すると、このアプリに登録した全てのデータは削除されます。"
     destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,13 @@ Rails.application.routes.draw do
   delete '/me', to: 'users#destroy'
   resources :expressions
   resources :bookmarked_expressions, only: [:index]
+  resources :memorised_expressions, only: [:index]
   resource :quiz, only: [:show]
   namespace :api do
     resources :expressions, only: [:index, :edit]
     resource :quiz, only: [:show]
     get '/bookmarked_expressions', to: 'bookmarkings#index'
+    get '/memorised_expressions', to: 'memorisings#index'
     post '/bookmarked_expressions', to: 'bookmarkings#create'
     post '/memorised_expressions', to: 'memorisings#create'
   end

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -63,12 +63,14 @@ RSpec.describe Expression, type: :model do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
     let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
     before do
       FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+      FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
     end
 
-    it 'return expressions that belongs to the user but does not belong to bookmarking' do
+    it 'return expressions that belongs to the user but does not belong to bookmarking and memorising' do
       expect(described_class.find_expressions_of_users_main_list(user.id).count).to eq 1
       expect(described_class.find_expressions_of_users_main_list(user.id)[0].expression_items[0].content).to eq second_expression_items[0].content
     end

--- a/spec/system/memorised_expressions_spec.rb
+++ b/spec/system/memorised_expressions_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Memorised expressions' do
+  context 'when user logged in' do
+    context 'when there are no data of memorisings' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note))
+        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+      end
+
+      it 'show a message that there are no data' do
+        visit '/memorised_expressions'
+        expect(page).to have_content user.name
+        expect(all('li').count).to eq 0
+        expect(page).to have_content '覚えた語彙リストに登録している英単語またはフレーズはありません'
+      end
+    end
+
+    context 'when there are data of memorisings' do
+      let!(:user) { FactoryBot.build(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+
+        visit '/quiz'
+
+        7.times do |n|
+          if has_text?('A platform on the side of a building, accessible from inside the building.')
+            fill_in('解答を入力', with: 'balcony')
+          elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
+            fill_in('解答を入力', with: 'veranda')
+          elsif has_text?(first_expression_items[0].explanation)
+            fill_in('解答を入力', with: first_expression_items[0].content)
+          elsif has_text?(first_expression_items[1].explanation)
+            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_items[2].explanation)
+            fill_in('解答を入力', with: first_expression_items[2].content)
+          elsif has_text?(second_expression_items[0].explanation)
+            fill_in('解答を入力', with: second_expression_items[0].content)
+          elsif has_text?(second_expression_items[1].explanation)
+            fill_in('解答を入力', with: second_expression_items[1].content)
+          end
+          click_button 'クイズに解答する'
+          n < 6 ? click_button('次へ') : click_button('クイズの結果を確認する')
+        end
+        click_button '保存する'
+
+        visit '/memorised_expressions'
+      end
+
+      it 'show a list of memorised expressions' do
+        expect(all('li').count).to eq 3
+        expect(page).not_to have_content '覚えた語彙リストに登録している英単語またはフレーズはありません'
+        expect(page).not_to have_content 'ログインしていないため閲覧できません'
+      end
+
+      it 'check titles and links' do
+        expect(first('li')).to have_link 'balcony and Veranda', href: expression_path(ExpressionItem.where(content: 'balcony').last.expression)
+        expect(all('li')[1]).to have_link "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}",
+                                          href: expression_path(ExpressionItem.where(content: first_expression_items[0].content).last.expression)
+        expect(all('li').last).to have_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}",
+                                            href: expression_path(ExpressionItem.where(content: second_expression_items[0].content).last.expression)
+      end
+    end
+
+    context 'when memorisings were made by two different times' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      before do
+        FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
+
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+
+        visit '/quiz'
+
+        2.times do |n|
+          if has_text?(first_expression_items[0].explanation)
+            fill_in('解答を入力', with: first_expression_items[0].content)
+          elsif has_text?(first_expression_items[1].explanation)
+            fill_in('解答を入力', with: first_expression_items[1].content)
+          end
+          click_button 'クイズに解答する'
+          n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
+        end
+        click_button '保存する'
+
+        visit '/memorised_expressions'
+      end
+
+      it 'check order' do
+        expect(first('li')).to have_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}",
+                                         href: expression_path(ExpressionItem.where(content: second_expression_items[0].content).last.expression)
+        expect(all('li')[1]).to have_link "#{third_expression_items[0].content}, #{third_expression_items[1].content} and #{third_expression_items[2].content}",
+                                          href: expression_path(ExpressionItem.where(content: third_expression_items[0].content).last.expression)
+        expect(all('li').last).to have_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}",
+                                            href: expression_path(ExpressionItem.where(content: first_expression_items[0].content).last.expression)
+      end
+    end
+  end
+
+  context 'when user is not logged in' do
+    let(:user) { FactoryBot.build(:user) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
+      visit '/quiz'
+
+      2.times do |n|
+        if has_text?('A platform on the side of a building, accessible from inside the building.')
+          fill_in('解答を入力', with: 'balcony')
+        else
+          fill_in('解答を入力', with: 'veranda')
+        end
+        click_button 'クイズに解答する'
+        n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      click_button '保存する'
+
+      find('label', text: user.name).click
+      click_button 'Log out'
+    end
+
+    it 'show message that is not logged in' do
+      visit '/memorised_expressions'
+      expect(page).to have_button 'Sign up/Log in with Google'
+      expect(all('li').count).to eq 0
+      expect(page).to have_content 'ログインしていないため閲覧できません'
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #115 

## Summary
覚えた語彙リストに保存された英単語・フレーズの一覧を表示できるようにした。
それに合わせて英単語・フレーズのメインリストに表示される内容とそのリストから出題されるクイズの内容を覚えた語彙リストに保存されている英単語・フレーズを除いたものにした。