### PR TITLE
Add the function of previous and next button on expression detail page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,8 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !!current_user
   end
+
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
+  end
 end

--- a/app/controllers/bookmarked_expressions_controller.rb
+++ b/app/controllers/bookmarked_expressions_controller.rb
@@ -3,5 +3,7 @@
 class BookmarkedExpressionsController < ApplicationController
   def index
     @bookmarkings = current_user.bookmarkings if logged_in?
+    session.delete(:forwarding_url)
+    store_location
   end
 end

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -9,7 +9,10 @@ class ExpressionsController < ApplicationController
   # end
 
   # GET /expressions/1 or /expressions/1.json
-  def show; end
+  def show
+    @list = session[:forwarding_url]
+    @user = current_user
+  end
 
   # GET /expressions/new
   def new; end
@@ -40,7 +43,7 @@ class ExpressionsController < ApplicationController
 
   # DELETE /expressions/1 or /expressions/1.json
   def destroy
-    expression = @expression.next || @expression.previous
+    expression = @expression.next(session[:forwarding_url], current_user) || @expression.previous(session[:forwarding_url], current_user)
 
     @expression.destroy
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,8 @@
 
 class HomeController < ApplicationController
   def index
+    session.delete(:forwarding_url)
+    store_location
     @expressions = if logged_in?
                      Expression.find_expressions_of_users_main_list(current_user.id)
                    else

--- a/app/controllers/memorised_expressions_controller.rb
+++ b/app/controllers/memorised_expressions_controller.rb
@@ -3,5 +3,7 @@
 class MemorisedExpressionsController < ApplicationController
   def index
     @memorisings = current_user.memorisings if logged_in?
+    session.delete(:forwarding_url)
+    store_location
   end
 end

--- a/app/models/example.rb
+++ b/app/models/example.rb
@@ -2,4 +2,13 @@
 
 class Example < ApplicationRecord
   belongs_to :expression_item
+
+  def self.copy_examples!(expression_item, new_expression_item)
+    expression_item.examples.each do |example|
+      new_example = Example.new
+      new_example.content = example.content
+      new_example.expression_item_id = new_expression_item.id
+      new_example.save!
+    end
+  end
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -40,7 +40,7 @@ class Expression < ApplicationRecord
   def self.find_expressions_of_users_main_list(user_id)
     expressions = []
 
-    Expression.where('user_id = ?', user_id).order(:created_at).each do |expression|
+    Expression.where('user_id = ?', user_id).order(:created_at, :id).each do |expression|
       bookmarked_expression = Bookmarking.find_by(expression_id: expression.id)
       memorised_expression = Memorising.find_by(expression_id: expression.id)
 
@@ -52,11 +52,65 @@ class Expression < ApplicationRecord
     expressions
   end
 
-  def previous
-    Expression.order(created_at: :desc, id: :desc).find_by('created_at <= ? AND id < ?', created_at, id)
+  def previous_bookmarking(expression_id, user)
+    bookmarking = Bookmarking.find_by(expression_id:, user_id: user.id)
+    previous_bookmarking = user.bookmarkings.order(created_at: :desc, id: :desc).find_by('created_at <= ? AND id < ?', bookmarking.created_at, bookmarking.id)
+    previous_bookmarking.expression if previous_bookmarking
   end
 
-  def next
-    Expression.order(:created_at, :id).find_by('created_at >= ? AND id > ?', created_at, id)
+  def previous_expression(user)
+    if !!user
+      previous_expressions = []
+      expressions = Expression.find_expressions_of_users_main_list(user.id)
+      expressions.each_with_index do |expression, i|
+        previous_expressions.push(expressions[i - 1]) if self == expression && i - 1 >= 0
+      end
+      previous_expressions[0]
+    else
+      Expression.where(user_id: nil).order(created_at: :desc, id: :desc).find_by('created_at <= ? AND id < ?', created_at, id)
+    end
+  end
+
+  def previous(list, user)
+    if list
+      if list.match?(/bookmarked_expressions$/)
+        previous_bookmarking(id, user)
+      else
+        previous_expression(user)
+      end
+    else
+      previous_expression(user)
+    end
+  end
+
+  def next_bookmarking(expression_id, user)
+    bookmarking = Bookmarking.find_by(expression_id:, user_id: user.id)
+    next_bookmarking = user.bookmarkings.order(:created_at, :id).find_by('created_at >= ? AND id > ?', bookmarking.created_at, bookmarking.id)
+    next_bookmarking.expression if next_bookmarking
+  end
+
+  def next_expression(user)
+    if !!user
+      next_expressions = []
+      expressions = Expression.find_expressions_of_users_main_list(user.id)
+      expressions.each_with_index do |expression, i|
+        next_expressions.push(expressions[i + 1]) if self == expression
+      end
+      next_expressions[0]
+    else
+      Expression.where(user_id: nil).order(:created_at, :id).find_by('created_at >= ? AND id > ?', created_at, id)
+    end
+  end
+
+  def next(list, user)
+    if list
+      if list.match?(/bookmarked_expressions$/)
+        next_bookmarking(id, user)
+      else
+        next_expression(user)
+      end
+    else
+      next_expression(user)
+    end
   end
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -58,6 +58,12 @@ class Expression < ApplicationRecord
     previous_bookmarking.expression if previous_bookmarking
   end
 
+  def previous_memorising(expression_id, user)
+    memorising = Memorising.find_by(expression_id:, user_id: user.id)
+    previous_memorising = user.memorisings.order(created_at: :desc, id: :desc).find_by('created_at <= ? AND id < ?', memorising.created_at, memorising.id)
+    previous_memorising.expression if previous_memorising
+  end
+
   def previous_expression(user)
     if !!user
       previous_expressions = []
@@ -75,6 +81,8 @@ class Expression < ApplicationRecord
     if list
       if list.match?(/bookmarked_expressions$/)
         previous_bookmarking(id, user)
+      elsif list.match?(/memorised_expressions$/)
+        previous_memorising(id, user)
       else
         previous_expression(user)
       end
@@ -87,6 +95,12 @@ class Expression < ApplicationRecord
     bookmarking = Bookmarking.find_by(expression_id:, user_id: user.id)
     next_bookmarking = user.bookmarkings.order(:created_at, :id).find_by('created_at >= ? AND id > ?', bookmarking.created_at, bookmarking.id)
     next_bookmarking.expression if next_bookmarking
+  end
+
+  def next_memorising(expression_id, user)
+    memorising = Memorising.find_by(expression_id:, user_id: user.id)
+    next_memorising = user.memorisings.order(:created_at, :id).find_by('created_at >= ? AND id > ?', memorising.created_at, memorising.id)
+    next_memorising.expression if next_memorising
   end
 
   def next_expression(user)
@@ -106,6 +120,8 @@ class Expression < ApplicationRecord
     if list
       if list.match?(/bookmarked_expressions$/)
         next_bookmarking(id, user)
+      elsif list.match?(/memorised_expressions$/)
+        next_memorising(id, user)
       else
         next_expression(user)
       end

--- a/app/models/expression_item.rb
+++ b/app/models/expression_item.rb
@@ -6,4 +6,16 @@ class ExpressionItem < ApplicationRecord
   accepts_nested_attributes_for :examples, reject_if: lambda { |attributes|
     attributes['content'].blank?
   }
+
+  def self.copy_expression_items!(expression, new_expression)
+    expression.expression_items.each do |expression_item|
+      new_expression_item = ExpressionItem.new
+      new_expression_item.content = expression_item.content
+      new_expression_item.explanation = expression_item.explanation
+      new_expression_item.expression_id = new_expression.id
+      new_expression_item.save!
+
+      Example.copy_examples!(expression_item, new_expression_item)
+    end
+  end
 end

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -42,7 +42,7 @@ div
 
   = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
 
-- if @expression.previous
-  = link_to t('.back'), expression_path(@expression.previous), data: { turbo: false }
-- if @expression.next
-  = link_to t('.next'), expression_path(@expression.next), data: { turbo: false }
+- if @expression.previous(@list, @user)
+  = link_to t('.back'), expression_path(@expression.previous(@list, @user)), data: { turbo: false }
+- if @expression.next(@list, @user)
+  = link_to t('.next'), expression_path(@expression.next(@list, @user)), data: { turbo: false }

--- a/spec/models/example_spec.rb
+++ b/spec/models/example_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Example, type: :model do
+  describe '.copy_examples!' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+    let!(:example1) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
+    let!(:example2) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
+    let!(:example3) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
+
+    it 'check if examples are copied' do
+      new_expression = Expression.new
+      new_expression.user_id = user.id
+      new_expression.save!
+
+      new_expression_item = ExpressionItem.new
+      new_expression_item.content = first_expression_items[0].content
+      new_expression_item.explanation = first_expression_items[0].explanation
+      new_expression_item.expression_id = new_expression.id
+      new_expression_item.save!
+
+      expect(described_class.where(content: example1.content).count).to eq 1
+      expect(described_class.where(content: example2.content).count).to eq 1
+
+      expect { described_class.copy_examples!(first_expression_items[0], new_expression_item) }.to change(described_class, :count).by(3)
+      expect(described_class.where(content: example1.content).count).to eq 2
+      expect(described_class.where(content: example2.content).count).to eq 2
+      expect(described_class.where(content: example3.content).count).to eq 2
+    end
+  end
+end

--- a/spec/models/expression_item_spec.rb
+++ b/spec/models/expression_item_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExpressionItem, type: :model do
+  describe '.copy_expression_items!' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+
+    it 'check if expression_items are copied' do
+      new_expression = Expression.new
+      new_expression.note = first_expression_items[0].expression.note
+      new_expression.user_id = user.id
+      new_expression.save!
+
+      expect { described_class.copy_expression_items!(first_expression_items[0].expression, new_expression) }.to change(described_class, :count).by(2)
+      expect(described_class.where(content: first_expression_items[0].content).count).to eq 2
+      expect(described_class.where(content: first_expression_items[1].content).count).to eq 2
+    end
+  end
+end

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -4,41 +4,205 @@ require 'rails_helper'
 
 RSpec.describe Expression, type: :model do
   describe '#next' do
-    it 'get next expression' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when user has not logged in' do
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
-      expect(first_expression_items[0].expression.next).to eq second_expression_items[0].expression
+      it 'get next expression' do
+        expect(first_expression_items[0].expression.next('/', nil)).to eq second_expression_items[0].expression
+      end
+
+      it 'get next expression even though the next id is missing' do
+        second_expression_items[0].expression.destroy
+
+        expect(first_expression_items[0].expression.next('/', nil)).to eq third_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(third_expression_items[0].expression.next('/', nil)).to eq nil
+      end
     end
 
-    it 'get next expression even though the next id is missing' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when user has logged in and first argument is root' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
-      second_expression_items[0].expression.destroy
+      it 'get next expression' do
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
 
-      expect(first_expression_items[0].expression.next).to eq third_expression_items[0].expression
+        expect(first_expression_items[0].expression.next('/', user)).to eq fourth_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(fourth_expression_items[0].expression.next('/', user)).to eq nil
+      end
+    end
+
+    context 'when user has logged in and first argument is bookmarked_expressions' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get next expression' do
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq fourth_expression_items[0].expression
+      end
+
+      it 'get next expression when the bookmark is created different order to expression' do
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+
+        expect(fourth_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq first_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq nil
+      end
+    end
+
+    context 'when first argument is nil and second argument is record of user' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get next expression' do
+        expect(first_expression_items[0].expression.next(nil, user)).to eq second_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(second_expression_items[0].expression.next(nil, user)).to eq nil
+      end
+    end
+
+    context 'when first argument and second argument are nil' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+
+      it 'get next expression' do
+        expect(first_expression_items[0].expression.next(nil, nil)).to eq third_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(third_expression_items[0].expression.next(nil, nil)).to eq nil
+      end
     end
   end
 
   describe '#previous' do
-    it 'get previous expression' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when user has not logged in' do
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
-      expect(second_expression_items[0].expression.previous).to eq first_expression_items[0].expression
+      it 'get previous expression' do
+        expect(second_expression_items[0].expression.previous('/', nil)).to eq first_expression_items[0].expression
+      end
+
+      it 'get previous expression even though the previous id is missing' do
+        third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        second_expression_items[0].expression.destroy
+
+        expect(third_expression_items[0].expression.previous('/', nil)).to eq first_expression_items[0].expression
+      end
     end
 
-    it 'get previous expression even though the previous id is missing' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when user has logged in and first argument is root' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
-      second_expression_items[0].expression.destroy
+      it 'get previous expression' do
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
 
-      expect(third_expression_items[0].expression.previous).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous('/', user)).to eq first_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(first_expression_items[0].expression.previous('/', user)).to eq nil
+      end
+    end
+
+    context 'when user has logged in and first argument is bookmarked_expressions' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get previous expression' do
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
+
+        expect(fourth_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq first_expression_items[0].expression
+      end
+
+      it 'get previous expression when the bookmark is created different order to expression' do
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq second_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+
+        expect(second_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq nil
+      end
+    end
+
+    context 'when first argument is nil and second argument is record of user' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get previous expression' do
+        expect(second_expression_items[0].expression.previous(nil, user)).to eq first_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expect(first_expression_items[0].expression.previous(nil, user)).to eq nil
+      end
+    end
+
+    context 'when first argument and second argument are nil' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+
+      it 'get previous expression' do
+        expect(third_expression_items[0].expression.previous(nil, nil)).to eq first_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        expression = ExpressionItem.find_by(content: 'balcony').expression
+        expect(expression.previous(nil, nil)).to eq nil
+      end
     end
   end
 

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -76,6 +76,39 @@ RSpec.describe Expression, type: :model do
       end
     end
 
+    context 'when user has logged in and first argument is memorised_expressions' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get next expression' do
+        FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.next('/memorised_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next('/memorised_expressions', user)).to eq fourth_expression_items[0].expression
+      end
+
+      it 'get next expression when the memorised expression is created different order to expression' do
+        FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
+
+        expect(fourth_expression_items[0].expression.next('/memorised_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next('/memorised_expressions', user)).to eq first_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.next('/memorised_expressions', user)).to eq nil
+      end
+    end
+
     context 'when first argument is nil and second argument is record of user' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -172,6 +205,39 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
 
         expect(second_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq nil
+      end
+    end
+
+    context 'when user has logged in and first argument is memorised_expressions' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+      it 'get previous expression' do
+        FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
+
+        expect(fourth_expression_items[0].expression.previous('/memorised_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous('/memorised_expressions', user)).to eq first_expression_items[0].expression
+      end
+
+      it 'get previous expression when the bookmark is created different order to expression' do
+        FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
+        FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
+
+        expect(first_expression_items[0].expression.previous('/memorised_expressions', user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous('/memorised_expressions', user)).to eq fourth_expression_items[0].expression
+      end
+
+      it 'return nil if no record is found' do
+        FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
+
+        expect(second_expression_items[0].expression.previous('/memorised_expressions', user)).to eq nil
       end
     end
 

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -130,6 +130,7 @@ RSpec.describe Expression, type: :model do
       let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
       it 'get next expression' do
+        expect(described_class.find_by(user_id: user.id)).to eq second_expression_items[0].expression
         expect(first_expression_items[0].expression.next(nil, nil)).to eq third_expression_items[0].expression
       end
 
@@ -262,6 +263,7 @@ RSpec.describe Expression, type: :model do
       let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
       it 'get previous expression' do
+        expect(described_class.find_by(user_id: user.id)).to eq second_expression_items[0].expression
         expect(third_expression_items[0].expression.previous(nil, nil)).to eq first_expression_items[0].expression
       end
 

--- a/spec/system/bookmarked_expressions_spec.rb
+++ b/spec/system/bookmarked_expressions_spec.rb
@@ -128,6 +128,8 @@ RSpec.describe 'Bookmarked expressions' do
     end
 
     it 'show message that is not logged in' do
+      expect(page).to have_content 'ログアウトしました'
+
       visit '/bookmarked_expressions'
       expect(page).to have_button 'Sign up/Log in with Google'
       expect(all('li').count).to eq 0

--- a/spec/system/expressions/expression_delete_spec.rb
+++ b/spec/system/expressions/expression_delete_spec.rb
@@ -4,8 +4,9 @@ require 'rails_helper'
 
 RSpec.describe 'Expressions' do
   describe 'delete first expression' do
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+
     before do
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
       visit '/'
       click_link 'balcony and Veranda'
     end
@@ -35,42 +36,34 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if the next expression is on the page after deleting expression' do
-      delete_expression_item = ExpressionItem.find_by content: 'balcony'
-      next_expression = delete_expression_item.expression.next
       accept_confirm do
         click_button '削除'
       end
       expect(page).to have_content '英単語又はフレーズを削除しました'
 
-      next_expression.expression_items.each do |expression_item|
-        within '.title' do
-          expect(page).to have_content expression_item.content
-        end
+      within '.title' do
+        expect(page).to have_content "1. #{first_expression_items[0].content}"
+        expect(page).to have_content "2. #{first_expression_items[1].content}"
       end
     end
   end
 
   describe 'delete another expression' do
-    let(:expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
+    let!(:expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
     before do
-      expression_items
       visit "/expressions/#{expression_items[0].expression.id}"
     end
 
     it 'check if the previous expression is on the page after deleting expression which is last id' do
-      delete_expression = Expression.find expression_items[0].expression.id
-      previous_expression = delete_expression.previous
-
       accept_confirm do
         click_button '削除'
       end
       expect(page).to have_content '英単語又はフレーズを削除しました'
 
-      previous_expression.expression_items.each do |expression_item|
-        within '.title' do
-          expect(page).to have_content expression_item.content
-        end
+      within '.title' do
+        expect(page).to have_content '1. balcony'
+        expect(page).to have_content '2. Veranda'
       end
     end
   end

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -140,44 +140,143 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'next and back button' do
-    it 'check if there is no next button if the expression is the last one' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when the expressions page is visited through root' do
+      it 'check if there is no next button when the expression is the last one' do
+        first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
 
-      visit "/expressions/#{first_expression_items[0].expression.id}"
-      expect(page).to have_link '１つ前の英単語・フレーズへ', href: '/expressions/1'
-      expect(page).not_to have_link '次の英単語・フレーズへ'
+        visit '/'
+        click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{first_expression_items[0].expression.id}", ignore_query: true
+        expect(page).to have_link '１つ前の英単語・フレーズへ', href: '/expressions/1'
+        expect(page).not_to have_link '次の英単語・フレーズへ'
+      end
+
+      it 'check if there is no back button when the expression is the first one' do
+        expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+        visit '/'
+        click_link 'balcony and Veranda'
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path '/expressions/1'
+        expect(page).to have_link '次の英単語・フレーズへ', href: "/expressions/#{expression_items[0].expression.id}"
+        expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+      end
+
+      it 'check if there is no back and next button when expression is one in a list' do
+        visit '/'
+        click_link 'balcony and Veranda'
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path '/expressions/1'
+        expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+        expect(page).not_to have_link '次の英単語・フレーズへ'
+      end
+
+      it 'check next button' do
+        first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+        visit '/'
+        click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{first_expression_items[0].expression.id}", ignore_query: true
+
+        click_link '次の英単語・フレーズへ'
+        expect(page).to have_content "1. #{second_expression_items[0].content}"
+        expect(page).to have_current_path expression_path(second_expression_items[0].expression), ignore_query: true
+      end
+
+      it 'check back button' do
+        first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+
+        visit '/'
+        click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{second_expression_items[0].expression.id}", ignore_query: true
+        click_link '１つ前の英単語・フレーズへ'
+        expect(page).to have_content "1. #{first_expression_items[0].content}"
+        expect(page).to have_current_path expression_path(first_expression_items[0].expression), ignore_query: true
+      end
     end
 
-    it 'check if there is no back button if the expression is the first one' do
-      expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+    context 'when the expressions page is visited through bookmarked expressions list' do
+      let!(:user) { FactoryBot.create(:user) }
+      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
-      visit '/expressions/1'
-      expect(page).to have_link '次の英単語・フレーズへ', href: "/expressions/#{expression_items[0].expression.id}"
-      expect(page).not_to have_link '１つ前の英単語・フレーズへ'
-    end
+      before do
+        FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
+        FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
 
-    it 'check if there is no back and next button when expression is one in a list' do
-      visit '/expressions/1'
-      expect(page).not_to have_link '１つ前の英単語・フレーズへ'
-      expect(page).not_to have_link '次の英単語・フレーズへ'
-    end
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
 
-    it 'check next button' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+      end
 
-      visit "/expressions/#{first_expression_items[0].expression.id}"
-      click_link '次の英単語・フレーズへ'
-      expect(page).to have_current_path expression_path(second_expression_items[0].expression), ignore_query: true
-    end
+      it 'check next button' do
+        visit '/bookmarked_expressions'
+        click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
 
-    it 'check back button' do
-      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-      second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{second_expression_items[0].expression.id}", ignore_query: true
+        expect(page).to have_link '１つ前の英単語・フレーズへ'
+        expect(page).to have_link '次の英単語・フレーズへ'
+        click_link '次の英単語・フレーズへ'
 
-      visit "/expressions/#{second_expression_items[0].expression.id}"
-      click_link '１つ前の英単語・フレーズへ'
-      expect(page).to have_current_path expression_path(first_expression_items[0].expression), ignore_query: true
+        expect(page).to have_content "1. #{third_expression_items[0].content}"
+        expect(page).to have_current_path "/expressions/#{third_expression_items[0].expression.id}", ignore_query: true
+      end
+
+      it 'check back button' do
+        visit '/bookmarked_expressions'
+        click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
+
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{third_expression_items[0].expression.id}", ignore_query: true
+        expect(page).to have_link '１つ前の英単語・フレーズへ'
+        click_link '１つ前の英単語・フレーズへ'
+
+        expect(page).to have_content "1. #{second_expression_items[0].content}"
+        expect(page).to have_current_path "/expressions/#{second_expression_items[0].expression.id}", ignore_query: true
+      end
+
+      it 'check if there is no next button when the expression is the last one' do
+        visit '/bookmarked_expressions'
+        click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
+
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{third_expression_items[0].expression.id}", ignore_query: true
+        expect(page).not_to have_link '次の英単語・フレーズへ'
+      end
+
+      it 'check if there is no back button if the expression is the first one' do
+        visit '/bookmarked_expressions'
+        click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{first_expression_items[0].expression.id}", ignore_query: true
+        expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+      end
+
+      it 'check if there is no back and next button when expression is one in a list' do
+        first_expression_items[0].expression.destroy
+        third_expression_items[0].expression.destroy
+        expect(User.find(user.id).bookmarkings.count).to eq 1
+
+        visit '/bookmarked_expressions'
+        click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
+
+        expect(page).to have_content '下記の英単語・フレーズの違いについて'
+        expect(page).to have_current_path "/expressions/#{second_expression_items[0].expression.id}", ignore_query: true
+        expect(page).not_to have_link '１つ前の英単語・フレーズへ'
+        expect(page).not_to have_link '次の英単語・フレーズへ'
+      end
     end
   end
 end

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -117,10 +117,12 @@ RSpec.describe 'Expressions' do
       find('summary', text: 'ブックマークする英単語・フレーズ').click
       find('label', text: 'balcony and Veranda').click
       find('label', text: "#{two_expression_items[0].content} and #{two_expression_items[1].content}").click
-      click_button '保存する'
     end
 
     it 'check list of expressions' do
+      click_button '保存する'
+      expect(page).to have_content 'ブックマークしました！'
+
       visit '/'
       expect(all('li').count).to eq 3
 
@@ -138,13 +140,17 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if list of expressions has no data after adding all expressions to bookmarks' do
-      visit 'quiz'
+      click_button '保存する'
+      expect(page).to have_content 'ブックマークしました！'
+
+      visit '/quiz'
       12.times do |n|
         fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         n < 11 ? click_button('次へ') : click_button('クイズの結果を確認する')
       end
       click_button '保存する'
+      expect(page).to have_content 'ブックマークしました！'
 
       visit '/'
       expect(all('li').count).to eq 0

--- a/spec/system/memorised_expressions_spec.rb
+++ b/spec/system/memorised_expressions_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Memorised expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -60,17 +61,21 @@ RSpec.describe 'Memorised expressions' do
           n < 6 ? click_button('次へ') : click_button('クイズの結果を確認する')
         end
         click_button '保存する'
-
-        visit '/memorised_expressions'
       end
 
       it 'show a list of memorised expressions' do
+        expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
+        visit '/memorised_expressions'
+
         expect(all('li').count).to eq 3
         expect(page).not_to have_content '覚えた語彙リストに登録している英単語またはフレーズはありません'
         expect(page).not_to have_content 'ログインしていないため閲覧できません'
       end
 
       it 'check titles and links' do
+        expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
+        visit '/memorised_expressions'
+
         expect(first('li')).to have_link 'balcony and Veranda', href: expression_path(ExpressionItem.where(content: 'balcony').last.expression)
         expect(all('li')[1]).to have_link "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}",
                                           href: expression_path(ExpressionItem.where(content: first_expression_items[0].content).last.expression)
@@ -150,6 +155,8 @@ RSpec.describe 'Memorised expressions' do
     end
 
     it 'show message that is not logged in' do
+      expect(page).to have_content 'ログアウトしました'
+
       visit '/memorised_expressions'
       expect(page).to have_button 'Sign up/Log in with Google'
       expect(all('li').count).to eq 0

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -737,11 +737,10 @@ RSpec.describe 'Quiz' do
     describe 'two expressions are bookmarked and two expressions are saved to memorised words list' do
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
       let(:user) { FactoryBot.build(:user) }
 
       before do
-        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
-
         OmniAuth.config.test_mode = true
         OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
 
@@ -759,7 +758,13 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: first_expression_items[0].content)
           elsif has_text?(first_expression_items[1].explanation)
             fill_in('解答を入力', with: first_expression_items[1].content)
-          else
+          elsif has_text?(second_expression_items[0].explanation)
+            fill_in('解答を入力', with: '')
+          elsif has_text?(second_expression_items[1].explanation)
+            fill_in('解答を入力', with: '')
+          elsif has_text?(third_expression_items[0].explanation)
+            fill_in('解答を入力', with: '')
+          elsif has_text?(third_expression_items[1].explanation)
             fill_in('解答を入力', with: '')
           end
           click_button 'クイズに解答する'


### PR DESCRIPTION
## Issue
- #123 
- #116 
- #117 

## Summary
英単語・フレーズの詳細ページに設置されている`１つ前の英単語・フレーズへ`と`次の英単語・フレーズへ`ボタンを押すと、その英単語・フレーズが属しているリスト（デフォルト・ブックマーク・覚えた語彙リスト）に保存されている英単語・フレーズの中から１つ前の英単語・フレーズと次の英単語・フレーズが表示されるように変更した。

また落ちやすくなっていたテストの修正も行った。