### PR TITLE
Make login require to create, edit, see and delete expressions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,18 @@ class ApplicationController < ActionController::Base
     !!current_user
   end
 
+  def store_list
+    session.delete(:list_url)
+    session[:list_url] = request.original_url if request.get?
+  end
+
   def store_location
+    session.delete(:forwarding_url)
     session[:forwarding_url] = request.original_url if request.get?
+  end
+
+  def redirect_back_or_default
+    redirect_to(session[:forwarding_url] || root_path)
+    session.delete(:forwarding_url)
   end
 end

--- a/app/controllers/bookmarked_expressions_controller.rb
+++ b/app/controllers/bookmarked_expressions_controller.rb
@@ -4,5 +4,6 @@ class BookmarkedExpressionsController < ApplicationController
   def index
     @bookmarkings = current_user.bookmarkings if logged_in?
     store_list
+    store_location
   end
 end

--- a/app/controllers/bookmarked_expressions_controller.rb
+++ b/app/controllers/bookmarked_expressions_controller.rb
@@ -3,7 +3,6 @@
 class BookmarkedExpressionsController < ApplicationController
   def index
     @bookmarkings = current_user.bookmarkings if logged_in?
-    session.delete(:forwarding_url)
-    store_location
+    store_list
   end
 end

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -15,19 +15,17 @@ class ExpressionsController < ApplicationController
     if @expression.user_id.nil?
       @list = session[:list_url]
       @user = current_user
-      store_location
+      session.delete(:forwarding_url)
+      session[:forwarding_url] = root_path
     elsif logged_in?
       if @expression.user_id == current_user.id
         @list = session[:list_url]
         @user = current_user
-        store_location
       else
-        flash[:error] = '権限がないため閲覧できません'
-        redirect_back_or_default
+        redirect_to root_path, alert: '権限がないため閲覧できません'
       end
     else
-      flash[:error] = 'ログインが必要です'
-      redirect_back_or_default
+      redirect_to root_path, alert: 'ログインが必要です'
     end
   end
 
@@ -77,21 +75,15 @@ class ExpressionsController < ApplicationController
   def require_login
     return if logged_in?
 
-    previous_page = session[:forwarding_url]
     store_location
-    flash[:error] = 'ログインが必要です'
-    redirect_to(previous_page || root_path)
+    redirect_to root_path, alert: 'ログインが必要です'
   end
 
   def require_authority
     if logged_in?
-      unless @expression.user_id == current_user.id
-        flash[:error] = '権限がありません'
-        redirect_back_or_default
-      end
+      redirect_to root_path, alert: '権限がありません' unless @expression.user_id == current_user.id
     else
-      flash[:error] = 'ログインが必要です'
-      redirect_back_or_default
+      redirect_to root_path, alert: 'ログインが必要です'
     end
   end
 

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -2,6 +2,8 @@
 
 class ExpressionsController < ApplicationController
   before_action :set_expression, only: %i[show edit update destroy]
+  before_action :require_login, only: %i[new create]
+  before_action :require_authority, only: %i[edit update destroy]
 
   # GET /expressions or /expressions.json
   # def index
@@ -10,8 +12,23 @@ class ExpressionsController < ApplicationController
 
   # GET /expressions/1 or /expressions/1.json
   def show
-    @list = session[:forwarding_url]
-    @user = current_user
+    if @expression.user_id.nil?
+      @list = session[:list_url]
+      @user = current_user
+      store_location
+    elsif logged_in?
+      if @expression.user_id == current_user.id
+        @list = session[:list_url]
+        @user = current_user
+        store_location
+      else
+        flash[:error] = '権限がないため閲覧できません'
+        redirect_back_or_default
+      end
+    else
+      flash[:error] = 'ログインが必要です'
+      redirect_back_or_default
+    end
   end
 
   # GET /expressions/new
@@ -23,6 +40,7 @@ class ExpressionsController < ApplicationController
   # POST /expressions or /expressions.json
   def create
     @expression = Expression.new(expression_params)
+    @expression.user_id = current_user.id
     @expression.tags = Tag.find_tags_object(@expression.tags)
 
     if @expression.save
@@ -43,7 +61,7 @@ class ExpressionsController < ApplicationController
 
   # DELETE /expressions/1 or /expressions/1.json
   def destroy
-    expression = @expression.next(session[:forwarding_url], current_user) || @expression.previous(session[:forwarding_url], current_user)
+    expression = @expression.next(session[:list_url], current_user) || @expression.previous(session[:list_url], current_user)
 
     @expression.destroy
 
@@ -55,6 +73,27 @@ class ExpressionsController < ApplicationController
   end
 
   private
+
+  def require_login
+    return if logged_in?
+
+    previous_page = session[:forwarding_url]
+    store_location
+    flash[:error] = 'ログインが必要です'
+    redirect_to(previous_page || root_path)
+  end
+
+  def require_authority
+    if logged_in?
+      unless @expression.user_id == current_user.id
+        flash[:error] = '権限がありません'
+        redirect_back_or_default
+      end
+    else
+      flash[:error] = 'ログインが必要です'
+      redirect_back_or_default
+    end
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_expression

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -76,7 +76,7 @@ class ExpressionsController < ApplicationController
     return if logged_in?
 
     store_location
-    redirect_to root_path, alert: 'ログインが必要です'
+    redirect_to root_path, flash: { unauthorized_access_to_create: 'ログインが必要です' }
   end
 
   def require_authority

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@
 
 class HomeController < ApplicationController
   def index
-    session.delete(:forwarding_url)
+    store_list
     store_location
     @expressions = if logged_in?
                      Expression.find_expressions_of_users_main_list(current_user.id)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,11 +3,13 @@
 class HomeController < ApplicationController
   def index
     store_list
-    store_location
     @expressions = if logged_in?
                      Expression.find_expressions_of_users_main_list(current_user.id)
                    else
                      Expression.where(user_id: nil)
                    end
+    return if session[:forwarding_url]&.match?(/new$/)
+
+    store_location
   end
 end

--- a/app/controllers/memorised_expressions_controller.rb
+++ b/app/controllers/memorised_expressions_controller.rb
@@ -4,5 +4,6 @@ class MemorisedExpressionsController < ApplicationController
   def index
     @memorisings = current_user.memorisings if logged_in?
     store_list
+    store_location
   end
 end

--- a/app/controllers/memorised_expressions_controller.rb
+++ b/app/controllers/memorised_expressions_controller.rb
@@ -3,7 +3,6 @@
 class MemorisedExpressionsController < ApplicationController
   def index
     @memorisings = current_user.memorisings if logged_in?
-    session.delete(:forwarding_url)
-    store_location
+    store_list
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,8 @@ class SessionsController < ApplicationController
     session[:user_id] = user.id
     Expression.copy_initial_expressions!(user.id) unless user_or_nil
 
-    redirect_to root_path, notice: t('.success')
+    flash[:notice] = t('.success')
+    redirect_back_or_default
   end
 
   def destroy

--- a/app/javascript/VueMounter.js
+++ b/app/javascript/VueMounter.js
@@ -24,7 +24,7 @@ export default class VueMounter {
   }
 
   mount() {
-    document.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('turbo:load', () => {
       const elements = document.querySelectorAll('div[data-vue]')
       if (elements.length > 0) {
         elements.forEach((element) => {

--- a/app/views/bookmarked_expressions/index.html.slim
+++ b/app/views/bookmarked_expressions/index.html.slim
@@ -1,3 +1,4 @@
+p style="color: green" = notice
 - if @bookmarkings.blank?
   - if logged_in?
     p

--- a/app/views/expressions/edit.html.slim
+++ b/app/views/expressions/edit.html.slim
@@ -5,4 +5,4 @@ br
 div
   = link_to t('.go_to_show'), @expression
   '|
-  = link_to t('.go_to_index'), root_path, data: { turbo: false }
+  = link_to t('.go_to_index'), root_path

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -36,13 +36,13 @@ p style="color: green" = notice
         = tag.name
 
 div
-  = link_to t('.edit'), edit_expression_path(@expression), data: { turbo: false }
+  = link_to t('.edit'), edit_expression_path(@expression)
   '|
-  = link_to t('.go_to_index'), root_path, data: { turbo: false }
+  = link_to t('.go_to_index'), root_path
 
   = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
 
 - if @expression.previous(@list, @user)
-  = link_to t('.back'), expression_path(@expression.previous(@list, @user)), data: { turbo: false }
+  = link_to t('.back'), expression_path(@expression.previous(@list, @user))
 - if @expression.next(@list, @user)
-  = link_to t('.next'), expression_path(@expression.next(@list, @user)), data: { turbo: false }
+  = link_to t('.next'), expression_path(@expression.next(@list, @user))

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -1,4 +1,7 @@
 p style="color: green" = notice
+p = flash[:error]
+- if flash[:error] == 'ログインが必要です'
+  = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 
 .title
   h1
@@ -37,12 +40,11 @@ p style="color: green" = notice
 
 div
   = link_to t('.edit'), edit_expression_path(@expression)
-  '|
-  = link_to t('.go_to_index'), root_path
-
-  = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
+  - if logged_in? && @expression.user_id == current_user.id
+    = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
 
 - if @expression.previous(@list, @user)
   = link_to t('.back'), expression_path(@expression.previous(@list, @user))
 - if @expression.next(@list, @user)
   = link_to t('.next'), expression_path(@expression.next(@list, @user))
+= link_to t('.go_to_index'), root_path

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -39,8 +39,8 @@ p = flash[:error]
         = tag.name
 
 div
-  = link_to t('.edit'), edit_expression_path(@expression)
   - if logged_in? && @expression.user_id == current_user.id
+    = link_to t('.edit'), edit_expression_path(@expression)
     = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
 
 - if @expression.previous(@list, @user)

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -1,7 +1,4 @@
 p style="color: green" = notice
-p = flash[:error]
-- if flash[:error] == 'ログインが必要です'
-  = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 
 .title
   h1

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,7 +1,7 @@
 p style="color: green" = notice
-div
-  p = flash[:error]
-  - if flash[:error]
+.error
+  p = alert
+  - if alert == 'ログインが必要です'
     = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 
 - if @expressions.blank?

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -10,4 +10,8 @@ p style="color: green" = notice
 - else
     div(data-vue='ExpressionsList' data-vue-path='api/expressions')
 
+.unauthorized_access_to_create
+  p = flash[:unauthorized_access_to_create]
+  - if flash[:unauthorized_access_to_create]
+    = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 = link_to "+ #{t('.create')}", new_expression_path

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,7 +1,13 @@
 p style="color: green" = notice
+div
+  p = flash[:error]
+  - if flash[:error]
+    = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 
 - if @expressions.blank?
   p
     = t('.no_data')
 - else
     div(data-vue='ExpressionsList' data-vue-path='api/expressions')
+
+= link_to "+ #{t('.create')}", new_expression_path

--- a/app/views/memorised_expressions/index.html.slim
+++ b/app/views/memorised_expressions/index.html.slim
@@ -1,3 +1,4 @@
+p style="color: green" = notice
 - if @memorisings.blank?
   - if logged_in?
     p

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -16,4 +16,5 @@ header.mx-9.my-4
               li
                 = button_to 'Delete account', me_path, method: :delete, form: { data: { turbo_confirm: t('users.confirm_deletion_of_account') } }
         - else
-          = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }, class: 'font-medium text-lg'
+          .button-on-header
+            = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }, class: 'font-medium text-lg'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   home:
     index:
       no_data: このリストに登録されている英単語またはフレーズはありません
+      create: 新規作成
   bookmarked_expressions:
     index:
       no_data: ブックマークしている英単語またはフレーズはありません

--- a/spec/system/bookmarked_expressions_spec.rb
+++ b/spec/system/bookmarked_expressions_spec.rb
@@ -69,21 +69,21 @@ RSpec.describe 'Bookmarked expressions' do
         visit '/quiz'
 
         9.times do |n|
-          fill_in('解答を入力', with: '')
           click_button 'クイズに解答する'
           n < 8 ? click_button('次へ') : click_button('クイズの結果を確認する')
         end
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         find('label', text: 'balcony and Veranda').click
         click_button '保存する'
+        has_text? 'ブックマークしました！'
 
         visit '/quiz'
         2.times do |n|
-          fill_in('解答を入力', with: '')
           click_button 'クイズに解答する'
           n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
         end
         click_button '保存する'
+        has_text? 'ブックマークしました！'
 
         visit '/bookmarked_expressions'
       end

--- a/spec/system/expressions/expression_delete_spec.rb
+++ b/spec/system/expressions/expression_delete_spec.rb
@@ -3,12 +3,54 @@
 require 'rails_helper'
 
 RSpec.describe 'Expressions' do
-  describe 'delete first expression' do
-    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-
-    before do
+  describe 'authority' do
+    it 'check if expression is not deleted without login' do
       visit '/'
       click_link 'balcony and Veranda'
+      expect(page).not_to have_button '削除'
+    end
+
+    it 'check if the user who does not own expressions can not delete it' do
+      user1 = FactoryBot.create(:user)
+      user2 = FactoryBot.create(:user)
+      first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user1.id))
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user2.uid, info: { name: user2.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+      expect(page).to have_current_path root_path
+      expect(page).to have_content '権限がないため閲覧できません'
+    end
+
+    it 'check if expression which user_id is nil is not deleted' do
+      user1 = FactoryBot.create(:user)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user1.uid, info: { name: user1.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      expect(Expression.where('user_id = ?', user1.id).count).to eq 0
+      visit '/expressions/1'
+      expect(page).not_to have_button '削除'
+    end
+  end
+
+  describe 'delete first expression' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
+      click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
     end
 
     it 'check if expression is deleted' do
@@ -19,7 +61,7 @@ RSpec.describe 'Expressions' do
       end.to change(Expression, :count).by(-1).and change(ExpressionItem, :count).by(-2)
 
       visit '/'
-      expect(page).not_to have_link 'balcony and Veranda'
+      expect(page).not_to have_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
     end
 
     it 'check if the expression is not deleted when cancel button is clicked' do
@@ -27,15 +69,43 @@ RSpec.describe 'Expressions' do
         click_button '削除'
         expect(page.dismiss_confirm).to eq 'この英単語又はフレーズを本当に削除しますか？'
         within '.title' do
-          expect(page).to have_content 'balcony'
+          expect(page).to have_content first_expression_items[0].content
         end
         click_link '英単語・フレーズ一覧に戻る'
       end.to change(Expression, :count).by(0).and change(ExpressionItem, :count).by(0)
 
-      expect(page).to have_link 'balcony and Veranda'
+      expect(page).to have_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
     end
 
     it 'check if the next expression is on the page after deleting expression' do
+      accept_confirm do
+        click_button '削除'
+      end
+      expect(page).to have_content '英単語又はフレーズを削除しました'
+
+      within '.title' do
+        expect(page).to have_content "1. #{second_expression_items[0].content}"
+        expect(page).to have_content "2. #{second_expression_items[1].content}"
+      end
+    end
+  end
+
+  describe 'delete another expression' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
+      visit "/expressions/#{second_expression_items[0].expression.id}"
+    end
+
+    it 'check if the previous expression is on the page after deleting expression which is last id' do
       accept_confirm do
         click_button '削除'
       end
@@ -48,36 +118,22 @@ RSpec.describe 'Expressions' do
     end
   end
 
-  describe 'delete another expression' do
-    let!(:expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-
-    before do
-      visit "/expressions/#{expression_items[0].expression.id}"
-    end
-
-    it 'check if the previous expression is on the page after deleting expression which is last id' do
-      accept_confirm do
-        click_button '削除'
-      end
-      expect(page).to have_content '英単語又はフレーズを削除しました'
-
-      within '.title' do
-        expect(page).to have_content '1. balcony'
-        expect(page).to have_content '2. Veranda'
-      end
-    end
-  end
-
   describe 'delete last expression in a list' do
+    let(:user) { FactoryBot.build(:user) }
+
     it 'check if root page is on the screen when the last expression is deleted' do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
       visit '/'
+      click_button 'Sign up/Log in with Google'
       click_link 'balcony and Veranda'
       accept_confirm do
         click_button '削除'
       end
       has_text? '英単語又はフレーズを削除しました'
 
-      expect(Expression.count).to eq 0
+      expect(Expression.where('user_id = ?', user.id).count).to eq 0
       expect(page).to have_current_path root_path, ignore_query: true
       expect(page).to have_content 'このリストに登録されている英単語またはフレーズはありません'
     end

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -63,7 +63,15 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'new expression with examples, a note and a tag' do
+    let!(:user) { FactoryBot.create(:user) }
+
     before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
       visit '/expressions/new'
       fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')
       fill_in('２つ目の英単語 / フレーズ', with: 'at the beach')
@@ -94,8 +102,6 @@ RSpec.describe 'Expressions' do
     end
 
     it 'show details of the third expression' do
-      visit '/'
-      click_link 'on the beach, at the beach and around the beach'
       within '.expression2' do
         expect(page).to have_content 'around the beach'
         expect(page).to have_content 'explanation of around the beach'
@@ -103,8 +109,6 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if examples of first expression are on the page' do
-      visit '/'
-      click_link 'on the beach, at the beach and around the beach'
       within '.expression0' do
         expect(page).to have_content '例文'
         expect(page).to have_content 'example of on the beach'
@@ -112,8 +116,6 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if examples of second expression are on the page' do
-      visit '/'
-      click_link 'on the beach, at the beach and around the beach'
       within '.expression1' do
         expect(page).to have_content '例文'
         expect(page).to have_content 'example of at the beach'
@@ -121,8 +123,6 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if a note is on the page' do
-      visit '/'
-      click_link 'on the beach, at the beach and around the beach'
       within '.note' do
         expect(page).to have_content 'メモ'
         expect(page).to have_content 'note'
@@ -130,8 +130,6 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check if a tag is on the page' do
-      visit '/'
-      click_link 'on the beach, at the beach and around the beach'
       within '.tag' do
         expect(page).to have_content 'タグ'
         expect(page).to have_content 'preposition'
@@ -355,6 +353,49 @@ RSpec.describe 'Expressions' do
         expect(page).not_to have_link '１つ前の英単語・フレーズへ'
         expect(page).not_to have_link '次の英単語・フレーズへ'
       end
+    end
+  end
+
+  describe 'authority' do
+    let!(:user) { FactoryBot.create(:user) }
+    let(:new_user) { FactoryBot.build(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+    it 'check if user who does not own the expressions can not see it' do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+      expect(page).to have_current_path root_path
+      expect(page).to have_content '権限がないため閲覧できません'
+
+      visit "/expressions/#{second_expression_items[0].expression.id}"
+      expect(page).to have_current_path root_path
+      expect(page).to have_content '権限がないため閲覧できません'
+    end
+
+    it 'check if the user who owns the expressions can see it' do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+
+      within '.title' do
+        expect(page).to have_content "1. #{first_expression_items[0].content}"
+        expect(page).to have_content "2. #{first_expression_items[1].content}"
+      end
+    end
+
+    it 'check if the user can not see their expression without login' do
+      visit "/expressions/#{first_expression_items[0].expression.id}"
+      expect(page).to have_content 'ログインが必要です'
+      expect(page).to have_current_path root_path
     end
   end
 end

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -372,6 +372,9 @@ RSpec.describe 'Expressions' do
       visit "/expressions/#{first_expression_items[0].expression.id}"
       expect(page).to have_current_path root_path
       expect(page).to have_content '権限がないため閲覧できません'
+      within '.error' do
+        expect(page).not_to have_button 'Sign up/Log in with Google'
+      end
 
       visit "/expressions/#{second_expression_items[0].expression.id}"
       expect(page).to have_current_path root_path
@@ -396,6 +399,9 @@ RSpec.describe 'Expressions' do
       visit "/expressions/#{first_expression_items[0].expression.id}"
       expect(page).to have_content 'ログインが必要です'
       expect(page).to have_current_path root_path
+      within '.error' do
+        expect(page).to have_button 'Sign up/Log in with Google'
+      end
     end
   end
 end

--- a/spec/system/expressions/expression_edit_spec.rb
+++ b/spec/system/expressions/expression_edit_spec.rb
@@ -520,6 +520,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         click_link 'balcony and Veranda'
         click_link '編集'

--- a/spec/system/expressions/expression_edit_spec.rb
+++ b/spec/system/expressions/expression_edit_spec.rb
@@ -3,6 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe 'Expressions' do
+  describe 'links' do
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+
+      click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+      click_link '編集'
+    end
+
+    it 'check links' do
+      expect(page).to have_current_path edit_expression_path(first_expression_items[0].expression)
+      click_link '英単語・フレーズ一覧に戻る'
+      expect(page).to have_current_path root_path
+      expect(page).to have_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}",
+                                href: expression_path(first_expression_items[0].expression)
+    end
+  end
+
   describe 'get the right data that has not been edited yet to edit' do
     before do
       visit '/expressions/new'

--- a/spec/system/expressions/expression_edit_spec.rb
+++ b/spec/system/expressions/expression_edit_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Expressions' do
 
   describe 'get the right data which are already edited with right order to edit' do
     describe 'content and explanation of expression_items' do
-      let!(:user) { FactoryBot.build(:user) }
+      let(:user) { FactoryBot.build(:user) }
 
       before do
         OmniAuth.config.test_mode = true

--- a/spec/system/expressions/expressions_form_spec.rb
+++ b/spec/system/expressions/expressions_form_spec.rb
@@ -3,17 +3,37 @@
 require 'rails_helper'
 
 RSpec.describe 'Expressions' do
-  before do
-    visit '/expressions/new'
-  end
-
   describe 'create expressions' do
     before do
       FactoryBot.create(:tag)
     end
 
+    context 'when user has not logged in' do
+      it 'check if error message is shown' do
+        visit '/'
+        click_link '新規作成'
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'ログインが必要です'
+      end
+
+      it 'check if the form is not shown' do
+        visit '/expressions/new'
+        expect(page).to have_current_path root_path
+        expect(page).to have_content 'ログインが必要です'
+      end
+    end
+
     context 'when two phrases, the explanations, one example for each, the note and one tag are given' do
+      let!(:user) { FactoryBot.create(:user) }
+
       before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+        click_link '新規作成'
+
         fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')
         fill_in('２つ目の英単語 / フレーズ', with: 'at the beach')
         click_button '次へ'
@@ -37,7 +57,16 @@ RSpec.describe 'Expressions' do
     end
 
     context 'when three words, the explanations, one example for one word and tags without the note are given' do
+      let!(:user) { FactoryBot.create(:user) }
+
       before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+        visit '/expressions/new'
+
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
         fill_in('３つ目の英単語 / フレーズ', with: 'word3')
@@ -64,7 +93,16 @@ RSpec.describe 'Expressions' do
     end
 
     context 'when four words, the explanations, two examples for each and tags without the note are given' do
+      let!(:user) { FactoryBot.create(:user) }
+
       before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+        click_link '新規作成'
+
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
         fill_in('３つ目の英単語 / フレーズ', with: 'word3')
@@ -103,7 +141,16 @@ RSpec.describe 'Expressions' do
     end
 
     context 'when five words, the explanations, three example for two words and one tag without the note are given' do
+      let!(:user) { FactoryBot.create(:user) }
+
       before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+        visit '/'
+        click_button 'Sign up/Log in with Google'
+        click_link '新規作成'
+
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
         fill_in('２つ目の英単語 / フレーズ', with: 'word2')
         fill_in('３つ目の英単語 / フレーズ', with: 'word3')
@@ -140,6 +187,17 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'validation error' do
+    let!(:user) { FactoryBot.create(:user) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      click_link '新規作成'
+    end
+
     describe 'words and phrases' do
       it 'show validation error if only one word is given' do
         fill_in('１つ目の英単語 / フレーズ', with: 'word')
@@ -305,6 +363,17 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'the back button on the last page' do
+    let!(:user) { FactoryBot.create(:user) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      click_link '新規作成'
+    end
+
     context 'when two expressions are given' do
       before do
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')
@@ -397,6 +466,17 @@ RSpec.describe 'Expressions' do
   end
 
   describe 'step navigation' do
+    let(:user) { FactoryBot.build(:user) }
+
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      click_link '新規作成'
+    end
+
     describe 'on the first page' do
       it 'check step1' do
         within('.bg-yellow-200') do

--- a/spec/system/expressions/expressions_form_spec.rb
+++ b/spec/system/expressions/expressions_form_spec.rb
@@ -13,13 +13,21 @@ RSpec.describe 'Expressions' do
         visit '/'
         click_link '新規作成'
         expect(page).to have_current_path root_path
-        expect(page).to have_content 'ログインが必要です'
+        within '.unauthorized_access_to_create' do
+          expect(page).to have_content 'ログインが必要です'
+          expect(page).to have_button 'Sign up/Log in with Google'
+        end
+        expect(find('.error', visible: false)).not_to be_visible
       end
 
       it 'check if the form is not shown when user has not logged in' do
         visit '/expressions/new'
         expect(page).to have_current_path root_path
-        expect(page).to have_content 'ログインが必要です'
+        within '.unauthorized_access_to_create' do
+          expect(page).to have_content 'ログインが必要です'
+          expect(page).to have_button 'Sign up/Log in with Google'
+        end
+        expect(find('.error', visible: false)).not_to be_visible
       end
     end
 
@@ -34,7 +42,7 @@ RSpec.describe 'Expressions' do
         visit '/'
         click_link '新規作成'
         expect(page).to have_content 'ログインが必要です'
-        within '.error' do
+        within '.unauthorized_access_to_create' do
           click_button 'Sign up/Log in with Google'
         end
         expect(page).to have_current_path '/expressions/new'
@@ -48,7 +56,7 @@ RSpec.describe 'Expressions' do
         visit '/'
         click_link '新規作成'
         expect(page).to have_content 'ログインが必要です'
-        within '.error' do
+        within '.unauthorized_access_to_create' do
           click_button 'Sign up/Log in with Google'
         end
         expect(page).to have_current_path '/expressions/new'

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       visit '/quiz'
       16.times do |n|
-        fill_in('解答を入力', with: '')
         click_button 'クイズに解答する'
         n < 15 ? click_button('次へ') : click_button('クイズの結果を確認する')
       end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -23,6 +23,24 @@ RSpec.describe 'Sessions' do
       click_button 'Sign up/Log in with Google'
       expect(page).to have_content 'ログインしました'
     end
+
+    it 'check if current path is bookmarked_expressions after login' do
+      visit '/bookmarked_expressions'
+      within '.button-on-header' do
+        click_button 'Sign up/Log in with Google'
+      end
+      expect(page).to have_content 'ログインしました'
+      expect(page).to have_current_path '/bookmarked_expressions'
+    end
+
+    it 'check if current path is memorised_expressions after login' do
+      visit '/memorised_expressions'
+      within '.button-on-header' do
+        click_button 'Sign up/Log in with Google'
+      end
+      expect(page).to have_content 'ログインしました'
+      expect(page).to have_current_path '/memorised_expressions'
+    end
   end
 
   describe 'log out' do


### PR DESCRIPTION
## Issue
- #124 

## Summary
ログインしていない状態で英単語・フレーズの作成・編集・削除・初期データ以外の閲覧を不可とした。
### 具体的な内容
#### - 新規作成
ログインしていない状態でユーザーホームページに設置されている新規作成ボタンを押すと、ログインが必要な旨が表示されログインボタンを出力するようにした。

#### - 編集・削除
英単語・フレーズの詳細画面に設置されている編集と削除ボタンを、ユーザーが所有する英単語・フレーズ以外には表示しないようにした（所有するユーザーがログインしていない状況も含む）。もしアクセスがあった場合は、ユーザーホームページに遷移するようにした。

#### - 詳細画面（英単語・フレーズのデータ個別ページ）
ユーザーがログインしていない状態で閲覧できるのは初期データのみとし、ユーザーがログインすると自分が所有するデータと初期データが閲覧できるようにした。

---
また、ヘッダーに設置されているログインボタンをブックマーク一覧画面から押した際はログイン後のリダイレクトはブックマーク一覧に、覚えた語彙リストにいる状態で押した場合は覚えた語彙リストリダイレクトするようにした。
初期データの詳細画面にいる状態で押した場合は、ログインしても画面に変化がないのでユーザーホームにリダイレクトするようにした。