### PR TITLE
Fix the way of classifying by list that expression belongs to

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,11 +14,6 @@ class ApplicationController < ActionController::Base
     !!current_user
   end
 
-  def store_list
-    session.delete(:list_url)
-    session[:list_url] = request.original_url if request.get?
-  end
-
   def store_location
     session.delete(:forwarding_url)
     session[:forwarding_url] = request.original_url if request.get?

--- a/app/controllers/bookmarked_expressions_controller.rb
+++ b/app/controllers/bookmarked_expressions_controller.rb
@@ -3,7 +3,6 @@
 class BookmarkedExpressionsController < ApplicationController
   def index
     @bookmarkings = current_user.bookmarkings if logged_in?
-    store_list
     store_location
   end
 end

--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -13,13 +13,11 @@ class ExpressionsController < ApplicationController
   # GET /expressions/1 or /expressions/1.json
   def show
     if @expression.user_id.nil?
-      @list = session[:list_url]
       @user = current_user
       session.delete(:forwarding_url)
       session[:forwarding_url] = root_path
     elsif logged_in?
       if @expression.user_id == current_user.id
-        @list = session[:list_url]
         @user = current_user
       else
         redirect_to root_path, alert: '権限がないため閲覧できません'
@@ -59,7 +57,7 @@ class ExpressionsController < ApplicationController
 
   # DELETE /expressions/1 or /expressions/1.json
   def destroy
-    expression = @expression.next(session[:list_url], current_user) || @expression.previous(session[:list_url], current_user)
+    expression = @expression.next(current_user) || @expression.previous(current_user)
 
     @expression.destroy
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,6 @@
 
 class HomeController < ApplicationController
   def index
-    store_list
     @expressions = if logged_in?
                      Expression.find_expressions_of_users_main_list(current_user.id)
                    else

--- a/app/controllers/memorised_expressions_controller.rb
+++ b/app/controllers/memorised_expressions_controller.rb
@@ -3,7 +3,6 @@
 class MemorisedExpressionsController < ApplicationController
   def index
     @memorisings = current_user.memorisings if logged_in?
-    store_list
     store_location
   end
 end

--- a/app/models/expression.rb
+++ b/app/models/expression.rb
@@ -15,6 +15,14 @@ class Expression < ApplicationRecord
   }
   accepts_nested_attributes_for :tags
 
+  def bookmarking?
+    !!Bookmarking.find_by(expression_id: id, user_id:)
+  end
+
+  def memorising?
+    !!Memorising.find_by(expression_id: id, user_id:)
+  end
+
   def self.copy_initial_expressions!(user_id)
     Expression.where(user_id: nil).find_each do |expression|
       new_expression = Expression.new
@@ -30,10 +38,7 @@ class Expression < ApplicationRecord
     expressions = []
 
     Expression.where('user_id = ?', user_id).order(:created_at, :id).each do |expression|
-      bookmarked_expression = Bookmarking.find_by(expression_id: expression.id)
-      memorised_expression = Memorising.find_by(expression_id: expression.id)
-
-      next unless !bookmarked_expression && !memorised_expression
+      next unless !expression.bookmarking? && !expression.memorising?
 
       expressions.push(Expression.find(expression.id))
     end
@@ -65,15 +70,11 @@ class Expression < ApplicationRecord
     end
   end
 
-  def previous(list, user)
-    if list
-      if list.match?(/bookmarked_expressions$/)
-        previous_bookmarking(id, user)
-      elsif list.match?(/memorised_expressions$/)
-        previous_memorising(id, user)
-      else
-        previous_expression(user)
-      end
+  def previous(user)
+    if bookmarking?
+      previous_bookmarking(id, user)
+    elsif memorising?
+      previous_memorising(id, user)
     else
       previous_expression(user)
     end
@@ -104,15 +105,11 @@ class Expression < ApplicationRecord
     end
   end
 
-  def next(list, user)
-    if list
-      if list.match?(/bookmarked_expressions$/)
-        next_bookmarking(id, user)
-      elsif list.match?(/memorised_expressions$/)
-        next_memorising(id, user)
-      else
-        next_expression(user)
-      end
+  def next(user)
+    if bookmarking?
+      next_bookmarking(id, user)
+    elsif memorising?
+      next_memorising(id, user)
     else
       next_expression(user)
     end

--- a/app/views/expressions/show.html.slim
+++ b/app/views/expressions/show.html.slim
@@ -40,8 +40,8 @@ div
     = link_to t('.edit'), edit_expression_path(@expression)
     = button_to t('.delete'), @expression, method: :delete, data: { turbo_confirm: t('.confirm_deletion_of_expression') }
 
-- if @expression.previous(@list, @user)
-  = link_to t('.back'), expression_path(@expression.previous(@list, @user))
-- if @expression.next(@list, @user)
-  = link_to t('.next'), expression_path(@expression.next(@list, @user))
+- if @expression.previous(@user)
+  = link_to t('.back'), expression_path(@expression.previous(@user))
+- if @expression.next(@user)
+  = link_to t('.next'), expression_path(@expression.next(@user))
 = link_to t('.go_to_index'), root_path

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe Expression, type: :model do
       let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
       it 'get next expression' do
-        expect(first_expression_items[0].expression.next('/', nil)).to eq second_expression_items[0].expression
+        expect(first_expression_items[0].expression.next(nil)).to eq second_expression_items[0].expression
       end
 
       it 'get next expression even though the next id is missing' do
         second_expression_items[0].expression.destroy
 
-        expect(first_expression_items[0].expression.next('/', nil)).to eq third_expression_items[0].expression
+        expect(first_expression_items[0].expression.next(nil)).to eq third_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
-        expect(third_expression_items[0].expression.next('/', nil)).to eq nil
+        expect(third_expression_items[0].expression.next(nil)).to eq nil
       end
     end
 
-    context 'when user has logged in and first argument is root' do
+    context 'when user has logged in and url is root' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -35,15 +35,15 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.next('/', user)).to eq fourth_expression_items[0].expression
+        expect(first_expression_items[0].expression.next(user)).to eq fourth_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
-        expect(fourth_expression_items[0].expression.next('/', user)).to eq nil
+        expect(fourth_expression_items[0].expression.next(user)).to eq nil
       end
     end
 
-    context 'when user has logged in and first argument is bookmarked_expressions' do
+    context 'when user has logged in and url is bookmarked_expressions' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -55,8 +55,8 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq fourth_expression_items[0].expression
+        expect(first_expression_items[0].expression.next(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next(user)).to eq fourth_expression_items[0].expression
       end
 
       it 'get next expression when the bookmark is created different order to expression' do
@@ -65,18 +65,18 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
 
-        expect(fourth_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.next(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next(user)).to eq first_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
         FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.next('/bookmarked_expressions', user)).to eq nil
+        expect(first_expression_items[0].expression.next(user)).to eq nil
       end
     end
 
-    context 'when user has logged in and first argument is memorised_expressions' do
+    context 'when user has logged in and url is memorised_expressions' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -88,8 +88,8 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.next('/memorised_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.next('/memorised_expressions', user)).to eq fourth_expression_items[0].expression
+        expect(first_expression_items[0].expression.next(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next(user)).to eq fourth_expression_items[0].expression
       end
 
       it 'get next expression when the memorised expression is created different order to expression' do
@@ -98,44 +98,14 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
 
-        expect(fourth_expression_items[0].expression.next('/memorised_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.next('/memorised_expressions', user)).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.next(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.next(user)).to eq first_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
         FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.next('/memorised_expressions', user)).to eq nil
-      end
-    end
-
-    context 'when first argument is nil and second argument is record of user' do
-      let!(:user) { FactoryBot.create(:user) }
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-
-      it 'get next expression' do
-        expect(first_expression_items[0].expression.next(nil, user)).to eq second_expression_items[0].expression
-      end
-
-      it 'return nil if no record is found' do
-        expect(second_expression_items[0].expression.next(nil, user)).to eq nil
-      end
-    end
-
-    context 'when first argument and second argument are nil' do
-      let!(:user) { FactoryBot.create(:user) }
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-
-      it 'get next expression' do
-        expect(described_class.find_by(user_id: user.id)).to eq second_expression_items[0].expression
-        expect(first_expression_items[0].expression.next(nil, nil)).to eq third_expression_items[0].expression
-      end
-
-      it 'return nil if no record is found' do
-        expect(third_expression_items[0].expression.next(nil, nil)).to eq nil
+        expect(first_expression_items[0].expression.next(user)).to eq nil
       end
     end
   end
@@ -146,18 +116,18 @@ RSpec.describe Expression, type: :model do
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
 
       it 'get previous expression' do
-        expect(second_expression_items[0].expression.previous('/', nil)).to eq first_expression_items[0].expression
+        expect(second_expression_items[0].expression.previous(nil)).to eq first_expression_items[0].expression
       end
 
       it 'get previous expression even though the previous id is missing' do
         third_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
         second_expression_items[0].expression.destroy
 
-        expect(third_expression_items[0].expression.previous('/', nil)).to eq first_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous(nil)).to eq first_expression_items[0].expression
       end
     end
 
-    context 'when user has logged in and first argument is root' do
+    context 'when user has logged in and url is root' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -168,15 +138,15 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
 
-        expect(fourth_expression_items[0].expression.previous('/', user)).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous(user)).to eq first_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
-        expect(first_expression_items[0].expression.previous('/', user)).to eq nil
+        expect(first_expression_items[0].expression.previous(user)).to eq nil
       end
     end
 
-    context 'when user has logged in and first argument is bookmarked_expressions' do
+    context 'when user has logged in and url is bookmarked_expressions' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -188,8 +158,8 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:bookmarking, user:, expression: fourth_expression_items[0].expression)
 
-        expect(fourth_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous(user)).to eq first_expression_items[0].expression
       end
 
       it 'get previous expression when the bookmark is created different order to expression' do
@@ -198,18 +168,18 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:bookmarking, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq third_expression_items[0].expression
-        expect(fourth_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq second_expression_items[0].expression
+        expect(first_expression_items[0].expression.previous(user)).to eq third_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous(user)).to eq second_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
         FactoryBot.create(:bookmarking, user:, expression: second_expression_items[0].expression)
 
-        expect(second_expression_items[0].expression.previous('/bookmarked_expressions', user)).to eq nil
+        expect(second_expression_items[0].expression.previous(user)).to eq nil
       end
     end
 
-    context 'when user has logged in and first argument is memorised_expressions' do
+    context 'when user has logged in and url is memorised_expressions' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
       let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
@@ -221,8 +191,8 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: fourth_expression_items[0].expression)
 
-        expect(fourth_expression_items[0].expression.previous('/memorised_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.previous('/memorised_expressions', user)).to eq first_expression_items[0].expression
+        expect(fourth_expression_items[0].expression.previous(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous(user)).to eq first_expression_items[0].expression
       end
 
       it 'get previous expression when the bookmark is created different order to expression' do
@@ -231,45 +201,14 @@ RSpec.describe Expression, type: :model do
         FactoryBot.create(:memorising, user:, expression: third_expression_items[0].expression)
         FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
 
-        expect(first_expression_items[0].expression.previous('/memorised_expressions', user)).to eq third_expression_items[0].expression
-        expect(third_expression_items[0].expression.previous('/memorised_expressions', user)).to eq fourth_expression_items[0].expression
+        expect(first_expression_items[0].expression.previous(user)).to eq third_expression_items[0].expression
+        expect(third_expression_items[0].expression.previous(user)).to eq fourth_expression_items[0].expression
       end
 
       it 'return nil if no record is found' do
         FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
 
-        expect(second_expression_items[0].expression.previous('/memorised_expressions', user)).to eq nil
-      end
-    end
-
-    context 'when first argument is nil and second argument is record of user' do
-      let!(:user) { FactoryBot.create(:user) }
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-
-      it 'get previous expression' do
-        expect(second_expression_items[0].expression.previous(nil, user)).to eq first_expression_items[0].expression
-      end
-
-      it 'return nil if no record is found' do
-        expect(first_expression_items[0].expression.previous(nil, user)).to eq nil
-      end
-    end
-
-    context 'when first argument and second argument are nil' do
-      let!(:user) { FactoryBot.create(:user) }
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note)) }
-
-      it 'get previous expression' do
-        expect(described_class.find_by(user_id: user.id)).to eq second_expression_items[0].expression
-        expect(third_expression_items[0].expression.previous(nil, nil)).to eq first_expression_items[0].expression
-      end
-
-      it 'return nil if no record is found' do
-        expression = ExpressionItem.find_by(content: 'balcony').expression
-        expect(expression.previous(nil, nil)).to eq nil
+        expect(second_expression_items[0].expression.previous(user)).to eq nil
       end
     end
   end

--- a/spec/system/expressions/expression_edit_spec.rb
+++ b/spec/system/expressions/expression_edit_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
 
       visit '/expressions/1/edit'
       expect(page).to have_current_path root_path


### PR DESCRIPTION
## Issue
- #128 

## Summary
どのデータを表示するかをセッションを使って判断していたが、そのデータがどのリストに属しているか判断しデータを抽出するようにした。