### PR TITLE
Fix クイズに再挑戦 button not to start quiz when question does not exist

### DIFF
--- a/app/controllers/expressions_controller.rb
+++ b/app/controllers/expressions_controller.rb
@@ -20,10 +20,10 @@ class ExpressionsController < ApplicationController
       if @expression.user_id == current_user.id
         @user = current_user
       else
-        redirect_to root_path, alert: '権限がないため閲覧できません'
+        redirect_to root_path, alert: t('.no_authority')
       end
     else
-      redirect_to root_path, alert: 'ログインが必要です'
+      redirect_to root_path, alert: t('not_logged_in')
     end
   end
 
@@ -74,14 +74,14 @@ class ExpressionsController < ApplicationController
     return if logged_in?
 
     store_location
-    redirect_to root_path, flash: { unauthorized_access_to_create: 'ログインが必要です' }
+    redirect_to root_path, flash: { unauthorized_access_to_create: t('not_logged_in') }
   end
 
   def require_authority
     if logged_in?
-      redirect_to root_path, alert: '権限がありません' unless @expression.user_id == current_user.id
+      redirect_to root_path, alert: t('no_authority') unless @expression.user_id == current_user.id
     else
-      redirect_to root_path, alert: 'ログインが必要です'
+      redirect_to root_path, alert: t('not_logged_in')
     end
   end
 

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
 class QuizzesController < ApplicationController
-  def show; end
+  def show
+    return unless logged_in?
+
+    expressions = Expression.find_expressions_of_users_main_list(current_user.id)
+    return unless expressions.count.zero?
+
+    redirect_to root_path, notice: t('.no_data')
+  end
 end

--- a/app/javascript/components/word-quiz.vue
+++ b/app/javascript/components/word-quiz.vue
@@ -11,7 +11,7 @@
         <template
           v-for="(quizResource, index) in quizResources"
           :key="quizResource">
-          <p v-if="currentIndex === index">
+          <p v-if="currentIndex === index" class="content-of-question">
             {{ quizResource.explanation }}
           </p>
         </template>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,6 +28,7 @@ ja:
     destroy:
       success: 英単語又はフレーズを削除しました
     show:
+      no_authority: 権限がないため閲覧できません
       title: 下記の英単語・フレーズの違いについて
       explanation: 意味
       example: 例文
@@ -45,3 +46,5 @@ ja:
   quizzes:
     show:
       no_data: このリストのクイズに問題が存在しません
+  no_authority: 権限がありません
+  not_logged_in: ログインが必要です

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -42,3 +42,6 @@ ja:
     edit:
       go_to_show: 詳細画面に戻る
       go_to_index: 英単語・フレーズ一覧に戻る
+  quizzes:
+    show:
+      no_data: このリストのクイズに問題が存在しません

--- a/spec/system/expressions/expression_edit_spec.rb
+++ b/spec/system/expressions/expression_edit_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
       click_link '編集'
@@ -44,6 +45,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       visit '/expressions/1'
       expect(page).not_to have_link '編集'
     end
@@ -54,6 +56,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
 
       click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
       expect(page).to have_link '編集'
@@ -96,6 +99,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       visit edit_expression_path(first_expression_items[0].expression)
       expect(page).to have_current_path root_path
       expect(page).to have_content '権限がありません'
@@ -111,6 +115,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       visit '/expressions/new'
       fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')
@@ -213,6 +218,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         expression_item = ExpressionItem.where('content = ?', 'balcony').last
         visit "/expressions/#{expression_item.expression.id}"
@@ -258,6 +264,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         click_link '新規作成'
         fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')
@@ -302,6 +309,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         click_link 'balcony and Veranda'
         click_link '編集'
@@ -362,6 +370,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         click_link 'balcony and Veranda'
         click_link '編集'
@@ -426,6 +435,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
         click_link '新規作成'
 
         fill_in('１つ目の英単語 / フレーズ', with: 'on the beach')

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -462,6 +462,7 @@ RSpec.describe 'Quiz' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -538,6 +539,7 @@ RSpec.describe 'Quiz' do
         find('label', text: 'balcony and Veranda').click
 
         click_button '保存する'
+        expect(page).to have_content 'ブックマークしました！'
         click_button 'クイズに再挑戦'
 
         2.times do |n|
@@ -562,6 +564,7 @@ RSpec.describe 'Quiz' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -647,6 +650,7 @@ RSpec.describe 'Quiz' do
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         find('label', text: 'balcony and Veranda').click
         click_button '保存する'
+        expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
         click_button 'クイズに再挑戦'
 
         2.times do |n|
@@ -670,6 +674,7 @@ RSpec.describe 'Quiz' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -746,6 +751,7 @@ RSpec.describe 'Quiz' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -808,6 +814,7 @@ RSpec.describe 'Quiz' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -830,6 +837,7 @@ RSpec.describe 'Quiz' do
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         find('label', text: "#{second_expression_items[0].content} and #{second_expression_items[1].content}").click
         click_button '保存する'
+        has_text? 'ブックマーク・覚えた語彙リストに英単語・フレーズを保存しました！'
         click_button 'クイズに再挑戦'
 
         4.times do |n|


### PR DESCRIPTION
## Issue
- #120 

## Summary
デフォルトリストから始めたクイズの最終結果画面でクイズに再挑戦ボタンを押した時、デフォルトリストにデータが存在しない場合はルートパスにリダイレクトするようにした。