### PR TITLE
Create quiz that is from bookmarks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,4 +19,4 @@ RSpec/MultipleExpectations:
   Max: 6
 
 RSpec/ExampleLength:
-  Max: 14
+  Max: 18

--- a/app/controllers/api/bookmarked_expressions/quizzes_controller.rb
+++ b/app/controllers/api/bookmarked_expressions/quizzes_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::BookmarkedExpressions::QuizzesController < ApplicationController
+  def show
+    @quiz = []
+
+    current_user.bookmarkings.each do |bookmarking|
+      expression = Expression.find bookmarking.expression_id
+      expression.expression_items.each { |expression_item| @quiz.push expression_item }
+    end
+  end
+end

--- a/app/controllers/bookmarked_expressions/quizzes_controller.rb
+++ b/app/controllers/bookmarked_expressions/quizzes_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class BookmarkedExpressions::QuizzesController < ApplicationController
+  def show
+    if logged_in?
+      return unless current_user.bookmarkings.count.zero?
+
+      redirect_to bookmarked_expressions_path, notice: t('.no_data')
+    else
+      redirect_to bookmarked_expressions_path
+    end
+  end
+end

--- a/app/javascript/components/word-quiz.vue
+++ b/app/javascript/components/word-quiz.vue
@@ -50,6 +50,11 @@ import WordQuizResult from './word-quiz-result.vue'
 
 export default {
   name: 'WordQuiz',
+  props: {
+    path: {
+      type: String
+    }
+  },
   components: {
     WordQuizResult
   },
@@ -87,7 +92,7 @@ export default {
       this.isResult = true
     },
     async fetchQuizResources() {
-      const quizResources = await fetch('/api/quiz', {
+      const quizResources = await fetch(this.path, {
         method: 'GET',
         headers: { 'X-Requested-With': 'XMLHttpRequest' },
         credentials: 'same-origin'

--- a/app/views/api/bookmarked_expressions/quizzes/show.json.jbuilder
+++ b/app/views/api/bookmarked_expressions/quizzes/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @quiz do |resource|
+  json.content resource.content
+  json.explanation resource.explanation
+  json.expressionId resource.expression_id
+end

--- a/app/views/bookmarked_expressions/index.html.slim
+++ b/app/views/bookmarked_expressions/index.html.slim
@@ -8,3 +8,4 @@ p style="color: green" = notice
       = t('.unauthorized')
 - else
   div(data-vue='ExpressionsList' data-vue-path='api/bookmarked_expressions')
+  = link_to t('.start_quiz'), bookmarked_expressions_quiz_path

--- a/app/views/bookmarked_expressions/quizzes/show.html.slim
+++ b/app/views/bookmarked_expressions/quizzes/show.html.slim
@@ -1,0 +1,1 @@
+div(data-vue='WordQuiz' data-vue-path='/api/bookmarked_expressions/quiz')

--- a/app/views/quizzes/show.html.slim
+++ b/app/views/quizzes/show.html.slim
@@ -1,1 +1,1 @@
-div(data-vue='WordQuiz')
+div(data-vue='WordQuiz' data-vue-path='/api/quiz')

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,10 @@ ja:
     index:
       no_data: ブックマークしている英単語またはフレーズはありません
       unauthorized: ログインしていないため閲覧できません
+      start_quiz: クイズに挑戦
+    quizzes:
+      show:
+        no_data: このリストのクイズに問題が存在しません
   memorised_expressions:
     index:
       no_data: 覚えた語彙リストに登録している英単語またはフレーズはありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   resources :bookmarked_expressions, only: [:index]
   resources :memorised_expressions, only: [:index]
   resource :quiz, only: [:show]
+  namespace :bookmarked_expressions do
+    resource :quiz, only: [:show]
+  end
   namespace :api do
     resources :expressions, only: [:index, :edit]
     resource :quiz, only: [:show]
@@ -17,5 +20,8 @@ Rails.application.routes.draw do
     get '/memorised_expressions', to: 'memorisings#index'
     post '/bookmarked_expressions', to: 'bookmarkings#create'
     post '/memorised_expressions', to: 'memorisings#create'
+    namespace :bookmarked_expressions do
+      resource :quiz, only: [:show]
+    end
   end
 end

--- a/spec/system/bookmarked_expressions/quizzes_spec.rb
+++ b/spec/system/bookmarked_expressions/quizzes_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BookmarkedExpressions Quiz' do
+  context 'when user starts quiz from bookmark list' do
+    let!(:user1) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
+    let!(:fourth_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
+
+    before do
+      user2 = FactoryBot.create(:user)
+      fifth_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id))
+
+      FactoryBot.create(:bookmarking, user: user1, expression: first_expression_items[0].expression)
+      FactoryBot.create(:bookmarking, user: user1, expression: second_expression_items[0].expression)
+      FactoryBot.create(:bookmarking, user: user2, expression: fifth_expression_items[0].expression)
+      FactoryBot.create(:memorising, user: user1, expression: third_expression_items[0].expression)
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user1.uid, info: { name: user1.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+
+      visit bookmarked_expressions_quiz_path
+    end
+
+    it 'check the questions are from bookmarks' do
+      expect(page).to have_css 'p.content-of-question'
+      5.times do |n|
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(all('.move-to-bookmark-or-memorised-list li', visible: false).count).to eq 2
+      find('summary', text: 'ブックマークする英単語・フレーズ').click
+      expect(page).to have_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+      expect(page).to have_field "#{second_expression_items[0].content}, #{second_expression_items[1].content} and #{second_expression_items[2].content}"
+      expect(page).not_to have_field "#{third_expression_items[0].content}, #{third_expression_items[1].content} and #{third_expression_items[2].content}"
+      expect(page).not_to have_field "#{fourth_expression_items[0].content} and #{fourth_expression_items[1].content}"
+    end
+
+    it 'check the questions and answers are set correctly' do
+      5.times do |n|
+        if has_text?(first_expression_items[0].explanation)
+          fill_in('解答を入力', with: first_expression_items[0].content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        elsif has_text?(first_expression_items[1].explanation)
+          fill_in('解答を入力', with: first_expression_items[1].content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        elsif has_text?(second_expression_items[0].explanation)
+          fill_in('解答を入力', with: second_expression_items[0].content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        else
+          click_button 'クイズに解答する'
+        end
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+    end
+  end
+
+  context 'when new user starts quiz from bookmarks' do
+    let(:new_user) { FactoryBot.build(:user) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+
+    before do
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id))
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+
+      visit '/quiz'
+      9.times do |n|
+        click_button 'クイズに解答する'
+        n < 8 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      find('summary', text: 'ブックマークする英単語・フレーズ').click
+      find('label', text: 'balcony and Veranda').click
+      click_button '保存する'
+      has_text? 'ブックマークしました！'
+
+      visit bookmarked_expressions_path
+    end
+
+    it 'check the questions are from bookmarks' do
+      expect(page).to have_link 'クイズに挑戦'
+      click_link 'クイズに挑戦'
+      expect(page).to have_css 'p.content-of-question'
+      7.times do |n|
+        click_button 'クイズに解答する'
+        n < 6 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      find('summary', text: 'ブックマークする英単語・フレーズ').click
+      expect(all('.move-to-bookmark-or-memorised-list li').count).to eq 3
+      expect(page).to have_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+      expect(page).to have_field "#{second_expression_items[0].content}, #{second_expression_items[1].content} and #{second_expression_items[2].content}"
+      expect(page).to have_field "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
+    end
+  end
+
+  context 'when user does not have bookmarks' do
+    let(:new_user) { FactoryBot.build(:user) }
+
+    before do
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+      FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note))
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+    end
+
+    it 'check if the page is bookmarks list' do
+      expect(new_user.bookmarkings.count).to eq 0
+      expect(page).not_to have_link 'クイズに挑戦'
+      visit bookmarked_expressions_quiz_path
+      expect(page).to have_current_path bookmarked_expressions_path
+      expect(page).to have_content 'このリストのクイズに問題が存在しません'
+    end
+  end
+
+  context 'when user has not logged in' do
+    it 'check if the page is bookmarks list' do
+      visit bookmarked_expressions_path
+      expect(page).not_to have_link 'クイズに挑戦'
+
+      visit bookmarked_expressions_quiz_path
+      expect(page).to have_current_path bookmarked_expressions_path
+      expect(page).to have_content 'ログインしていないため閲覧できません'
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #126 

## Summary
ブックマークしている英単語・フレーズのクイズを実施できるようにした。
ユーザーがログインしていて、そのユーザーがブックマークしている英単語・フレーズがある場合、ブックマークリストに『クイズに挑戦』と表示されたリンクを設置し、そこからクイズを始められるようにした。
ブックマークしているデータのクイズをURLを叩いて実行しようとした際、ユーザーがログインしているがブックマークしているデータがない場合はブックマークリストにリダイレクトし、クイズの問題がない旨を表示。ユーザーがログインしていない際は、ブックマークのリストにリダイレクトし権限がない旨を表示。