### PR TITLE
Create result page for quiz which is from bookmarks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,4 +19,4 @@ RSpec/MultipleExpectations:
   Max: 7
 
 RSpec/ExampleLength:
-  Max: 18
+  Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/ClassLength:
   Max: 120
 
 RSpec/MultipleExpectations:
-  Max: 6
+  Max: 7
 
 RSpec/ExampleLength:
   Max: 18

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Max: 20
+
+RSpec/MultipleMemoizedHelpers:
+  Max: 8

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -363,14 +363,14 @@ export default {
       listOfExpressionIds.forEach((id) => {
         const contents = []
 
-        const expression = this.rawQuizResources.filter(
+        const expressionItems = this.rawQuizResources.filter(
           (quizResource) => quizResource.expressionId === id
         )
-        const lastIndex = expression.length - 1
-        expression.forEach((expressionItem, index) => {
+        const lastIndex = expressionItems.length - 1
+        expressionItems.forEach((expressionItem, index) => {
           if (index === lastIndex) {
             contents.push(`and ${expressionItem.content}`)
-          } else if (expression.length > 2 && index !== lastIndex - 1) {
+          } else if (expressionItems.length > 2 && index !== lastIndex - 1) {
             contents.push(`${expressionItem.content},`)
           } else {
             contents.push(expressionItem.content)
@@ -379,12 +379,12 @@ export default {
         if (type === 'correct') {
           this.listOfCorrectItems.push({
             content: contents.join(' '),
-            expressionId: expression[0].expressionId
+            expressionId: expressionItems[0].expressionId
           })
         } else if (type === 'wrong') {
           this.listOfWrongItems.push({
             content: contents.join(' '),
-            expressionId: expression[0].expressionId
+            expressionId: expressionItems[0].expressionId
           })
         }
       })

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -314,7 +314,9 @@ export default {
       this.classifyUserAnswersByExpressionId()
       this.classifyExpressionGroupsByRightOrWrong()
       this.convertExpressionIds(this.allCorrectExpressionIds, 'correct')
-      this.convertExpressionIds(this.wrongExpressionIds, 'wrong')
+      if (!this.isBookmarkedList) {
+        this.convertExpressionIds(this.wrongExpressionIds, 'wrong')
+      }
     },
     getNumberOfCorrectAnswers() {
       const correctAnswers = this.userAnswers.filter((userAnswer) =>
@@ -387,7 +389,7 @@ export default {
         }
       })
       this.sortItems(this.listOfCorrectItems)
-      this.sortItems(this.listOfWrongItems)
+      if (!this.isBookmarkedList) this.sortItems(this.listOfWrongItems)
     },
     sortItems(items) {
       items.sort((first, second) => first.expressionId - second.expressionId)
@@ -404,7 +406,12 @@ export default {
   mounted() {
     this.getNumberOfCorrectAnswers()
     this.createListOfItems()
-    this.defaultCheckbox(this.checkedContentsToBookmark, this.listOfWrongItems)
+    if (!this.isBookmarkedList) {
+      this.defaultCheckbox(
+        this.checkedContentsToBookmark,
+        this.listOfWrongItems
+      )
+    }
     this.defaultCheckbox(
       this.checkedContentsToMemorisedList,
       this.listOfCorrectItems

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -10,9 +10,13 @@
       }}
     </p>
   </div>
-  <div v-if="!isSaved" class="move-to-bookmark-or-memorised-list pb-8">
+  <div
+    v-if="!isSaved && movableExpressionExists"
+    class="move-to-bookmark-or-memorised-list pb-8">
     <div
-      v-if="listOfWrongItems.length > 0 && !isSavedBookmark"
+      v-if="
+        listOfWrongItems.length > 0 && !isSavedBookmark && !isBookmarkedList
+      "
       class="section-of-wrong-answers py-2.5">
       <input
         type="checkbox"
@@ -92,8 +96,10 @@
     </ul>
   </details>
   <div>
-    <p>{{ $t('quiz.result.recommendNextAction') }}</p>
-    <p class="text-red-600">{{ $t('quiz.result.important') }}</p>
+    <div v-if="movableExpressionExists">
+      <p>{{ $t('quiz.result.recommendNextAction') }}</p>
+      <p class="text-red-600">{{ $t('quiz.result.important') }}</p>
+    </div>
     <a>{{ $t('quiz.result.review') }}</a>
   </div>
   <button @click="getNewQuiz">{{ $t('quiz.result.tryAgain') }}</button>
@@ -137,7 +143,9 @@ export default {
       success: [],
       warning: false,
       failure: [],
-      unauthorized: false
+      unauthorized: false,
+      isBookmarkedList: this.isBookmarkedExpressionsPath(),
+      movableExpressionExists: true
     }
   },
   methods: {
@@ -383,6 +391,14 @@ export default {
     },
     sortItems(items) {
       items.sort((first, second) => first.expressionId - second.expressionId)
+    },
+    isBookmarkedExpressionsPath() {
+      return location.pathname === '/bookmarked_expressions/quiz'
+    },
+    checkExistenceOfMovableExpressions() {
+      if (this.isBookmarkedList && this.listOfCorrectItems.length === 0) {
+        this.movableExpressionExists = false
+      }
     }
   },
   mounted() {
@@ -393,6 +409,7 @@ export default {
       this.checkedContentsToMemorisedList,
       this.listOfCorrectItems
     )
+    this.checkExistenceOfMovableExpressions()
   }
 }
 </script>

--- a/app/models/concerns/recordable.rb
+++ b/app/models/concerns/recordable.rb
@@ -7,6 +7,11 @@ module Recordable
 
     transaction do
       exist_expression_ids.each do |expression_id|
+        if self == Memorising
+          bookmarking = Bookmarking.find_by(expression_id:)
+          bookmarking&.destroy
+        end
+
         object = new
         object.user_id = user_id
         object.expression_id = expression_id

--- a/spec/factories/expression_items.rb
+++ b/spec/factories/expression_items.rb
@@ -7,4 +7,39 @@ FactoryBot.define do
 
     association :expression, factory: :note
   end
+
+  factory :expression_item2, class: 'ExpressionItem' do
+    content { Faker::Verb.base }
+    explanation { Faker::Quote.matz }
+
+    association :expression, factory: :note
+  end
+
+  factory :expression_item3, class: 'ExpressionItem' do
+    content { Faker::Verb.base }
+    explanation { Faker::Quote.jack_handey }
+
+    association :expression, factory: :note
+  end
+
+  factory :expression_item4, class: 'ExpressionItem' do
+    content { Faker::Verb.base }
+    explanation { Faker::Quote.most_interesting_man_in_the_world }
+
+    association :expression, factory: :note
+  end
+
+  factory :expression_item5, class: 'ExpressionItem' do
+    content { Faker::Verb.base }
+    explanation { Faker::Quote.robin }
+
+    association :expression, factory: :note
+  end
+
+  factory :expression_item6, class: 'ExpressionItem' do
+    content { Faker::Verb.base }
+    explanation { Faker::Quotes::Shakespeare.hamlet_quote }
+
+    association :expression, factory: :note
+  end
 end

--- a/spec/models/expression_spec.rb
+++ b/spec/models/expression_spec.rb
@@ -214,18 +214,24 @@ RSpec.describe Expression, type: :model do
   end
 
   describe '.copy_initial_expressions!' do
-    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id)) }
-    let!(:example) { FactoryBot.create(:example, expression_item: second_expression_items[0]) }
+    let!(:expression) { FactoryBot.create(:empty_note) }
+    let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+
     let!(:user) { FactoryBot.create(:user) }
     let!(:user2) { FactoryBot.create(:user) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id)) }
+    let!(:example) { FactoryBot.create(:example, expression_item: second_expression_items[0]) }
+
+    before do
+      FactoryBot.create(:expression_item2, expression:)
+    end
 
     it 'check if expressions which user_id are nil are copied' do
       expect do
         described_class.copy_initial_expressions!(user.id)
       end.to change(described_class, :count).by(2).and change(ExpressionItem, :count).by(4).and change(Example, :count).by(2)
       expect(described_class.where('user_id = ?', user.id).count).to eq 2
-      expect(ExpressionItem.where('content = ?', first_expression_items[0].content).count).to eq 2
+      expect(ExpressionItem.where('content = ?', first_expression_item.content).count).to eq 2
       expect(Example.where('content = ?', example.content).count).to eq 1
     end
   end

--- a/spec/system/bookmarked_expressions/quizzes_spec.rb
+++ b/spec/system/bookmarked_expressions/quizzes_spec.rb
@@ -114,6 +114,46 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
       expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
       expect(page).not_to have_content '覚えた語彙リストに英単語・フレーズを保存しましたがブックマークは出来ませんでした'
     end
+
+    it 'check if bookmarking is destroyed when memorising is created' do
+      5.times do |n|
+        if has_text?(first_expression_items[0].explanation)
+          fill_in('解答を入力', with: first_expression_items[0].content)
+        elsif has_text?(first_expression_items[1].explanation)
+          fill_in('解答を入力', with: first_expression_items[1].content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-correct-answers')
+      expect do
+        click_button '保存する'
+        expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
+      end.to change(Bookmarking, :count).by(-1).and change(Memorising, :count).by(1)
+    end
+
+    it 'check if bookmarkings are destroyed when memorisings are created' do
+      5.times do |n|
+        if has_text?(first_expression_items[0].explanation)
+          fill_in('解答を入力', with: first_expression_items[0].content)
+        elsif has_text?(first_expression_items[1].explanation)
+          fill_in('解答を入力', with: first_expression_items[1].content)
+        elsif has_text?(second_expression_items[0].explanation)
+          fill_in('解答を入力', with: second_expression_items[0].content)
+        elsif has_text?(second_expression_items[1].explanation)
+          fill_in('解答を入力', with: second_expression_items[1].content)
+        elsif has_text?(second_expression_items[2].explanation)
+          fill_in('解答を入力', with: second_expression_items[2].content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-correct-answers')
+      expect do
+        click_button '保存する'
+        expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
+      end.to change(Bookmarking, :count).by(-2).and change(Memorising, :count).by(2)
+    end
   end
 
   context 'when new user starts quiz from bookmarks' do

--- a/spec/system/bookmarked_expressions/quizzes_spec.rb
+++ b/spec/system/bookmarked_expressions/quizzes_spec.rb
@@ -98,6 +98,22 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
       expect(page).not_to have_selector('.section-of-wrong-answers')
       expect(page).to have_button '保存する'
     end
+
+    it 'check if request for saving bookmarkings is not sent when memorising is saved' do
+      5.times do |n|
+        if has_text?(first_expression_items[0].explanation)
+          fill_in('解答を入力', with: first_expression_items[0].content)
+        elsif has_text?(first_expression_items[1].explanation)
+          fill_in('解答を入力', with: first_expression_items[1].content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-correct-answers')
+      click_button '保存する'
+      expect(page).to have_content '英単語・フレーズを覚えた語彙リストに保存しました！'
+      expect(page).not_to have_content '覚えた語彙リストに英単語・フレーズを保存しましたがブックマークは出来ませんでした'
+    end
   end
 
   context 'when new user starts quiz from bookmarks' do

--- a/spec/system/bookmarked_expressions/quizzes_spec.rb
+++ b/spec/system/bookmarked_expressions/quizzes_spec.rb
@@ -5,17 +5,23 @@ require 'rails_helper'
 RSpec.describe 'BookmarkedExpressions Quiz' do
   context 'when user starts quiz from bookmark list' do
     let!(:user1) { FactoryBot.create(:user) }
-    let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
-    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id)) }
+    let!(:expression1) { FactoryBot.create(:empty_note, user_id: user1.id) }
+    let!(:first_expression_item) { FactoryBot.create(:expression_item, expression: expression1) }
+    let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression: expression1) }
+
+    let!(:expression2) { FactoryBot.create(:empty_note, user_id: user1.id) }
+    let!(:third_expression_item) { FactoryBot.create(:expression_item3, expression: expression2) }
+    let!(:fourth_expression_item) { FactoryBot.create(:expression_item4, expression: expression2) }
+    let!(:fifth_expression_item) { FactoryBot.create(:expression_item5, expression: expression2) }
 
     before do
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id))
+      third_expression_items = FactoryBot.create_list(:expression_item6, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id))
+      FactoryBot.create_list(:expression_item6, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id))
       user2 = FactoryBot.create(:user)
-      fifth_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id))
+      fifth_expression_items = FactoryBot.create_list(:expression_item6, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id))
 
-      FactoryBot.create(:bookmarking, user: user1, expression: first_expression_items[0].expression)
-      FactoryBot.create(:bookmarking, user: user1, expression: second_expression_items[0].expression)
+      FactoryBot.create(:bookmarking, user: user1, expression: first_expression_item.expression)
+      FactoryBot.create(:bookmarking, user: user1, expression: third_expression_item.expression)
       FactoryBot.create(:bookmarking, user: user2, expression: fifth_expression_items[0].expression)
       FactoryBot.create(:memorising, user: user1, expression: third_expression_items[0].expression)
 
@@ -37,25 +43,25 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
       end
       expect(all('ul.user-answer-list li', visible: false).count).to eq 5
       find('summary', text: '自分の解答を表示').click
-      expect(page).to have_content "Answer: #{first_expression_items[0].content}"
-      expect(page).to have_content "Answer: #{first_expression_items[1].content}"
-      expect(page).to have_content "Answer: #{second_expression_items[0].content}"
-      expect(page).to have_content "Answer: #{second_expression_items[1].content}"
-      expect(page).to have_content "Answer: #{second_expression_items[2].content}"
+      expect(page).to have_content "Answer: #{first_expression_item.content}"
+      expect(page).to have_content "Answer: #{second_expression_item.content}"
+      expect(page).to have_content "Answer: #{third_expression_item.content}"
+      expect(page).to have_content "Answer: #{fourth_expression_item.content}"
+      expect(page).to have_content "Answer: #{fifth_expression_item.content}"
     end
 
     it 'check the questions and answers are set correctly' do
       5.times do |n|
-        if has_text?(first_expression_items[0].explanation)
-          fill_in('解答を入力', with: first_expression_items[0].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
           click_button 'クイズに解答する'
           expect(page).to have_content '◯ 正解!'
-        elsif has_text?(first_expression_items[1].explanation)
-          fill_in('解答を入力', with: first_expression_items[1].content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
           click_button 'クイズに解答する'
           expect(page).to have_content '◯ 正解!'
-        elsif has_text?(second_expression_items[0].explanation)
-          fill_in('解答を入力', with: second_expression_items[0].content)
+        elsif has_text?(third_expression_item.explanation)
+          fill_in('解答を入力', with: third_expression_item.content)
           click_button 'クイズに解答する'
           expect(page).to have_content '◯ 正解!'
         else
@@ -86,10 +92,10 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     it 'check if a section of moving expressions to memorised list is on the result page when some answers are correct' do
       5.times do |n|
-        if has_text?(first_expression_items[0].explanation)
-          fill_in('解答を入力', with: first_expression_items[0].content)
-        elsif has_text?(first_expression_items[1].explanation)
-          fill_in('解答を入力', with: first_expression_items[1].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
         end
         click_button 'クイズに解答する'
         n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -101,10 +107,10 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     it 'check if request for saving bookmarkings is not sent when memorising is saved' do
       5.times do |n|
-        if has_text?(first_expression_items[0].explanation)
-          fill_in('解答を入力', with: first_expression_items[0].content)
-        elsif has_text?(first_expression_items[1].explanation)
-          fill_in('解答を入力', with: first_expression_items[1].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
         end
         click_button 'クイズに解答する'
         n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -117,10 +123,10 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     it 'check if bookmarking is destroyed when memorising is created' do
       5.times do |n|
-        if has_text?(first_expression_items[0].explanation)
-          fill_in('解答を入力', with: first_expression_items[0].content)
-        elsif has_text?(first_expression_items[1].explanation)
-          fill_in('解答を入力', with: first_expression_items[1].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
         end
         click_button 'クイズに解答する'
         n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -134,16 +140,16 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     it 'check if bookmarkings are destroyed when memorisings are created' do
       5.times do |n|
-        if has_text?(first_expression_items[0].explanation)
-          fill_in('解答を入力', with: first_expression_items[0].content)
-        elsif has_text?(first_expression_items[1].explanation)
-          fill_in('解答を入力', with: first_expression_items[1].content)
-        elsif has_text?(second_expression_items[0].explanation)
-          fill_in('解答を入力', with: second_expression_items[0].content)
-        elsif has_text?(second_expression_items[1].explanation)
-          fill_in('解答を入力', with: second_expression_items[1].content)
-        elsif has_text?(second_expression_items[2].explanation)
-          fill_in('解答を入力', with: second_expression_items[2].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        elsif has_text?(third_expression_item.explanation)
+          fill_in('解答を入力', with: third_expression_item.content)
+        elsif has_text?(fourth_expression_item.explanation)
+          fill_in('解答を入力', with: fourth_expression_item.content)
+        elsif has_text?(fifth_expression_item.explanation)
+          fill_in('解答を入力', with: fifth_expression_item.content)
         end
         click_button 'クイズに解答する'
         n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -160,11 +166,11 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
     let(:new_user) { FactoryBot.build(:user) }
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
-    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note)) }
 
     before do
-      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id))
+      FactoryBot.create_list(:expression_item4, 2, expression: FactoryBot.create(:empty_note, user_id: user.id))
 
       OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
@@ -209,7 +215,7 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     before do
       FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
-      FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note))
+      FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note))
 
       OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })

--- a/spec/system/bookmarked_expressions_spec.rb
+++ b/spec/system/bookmarked_expressions_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe 'Bookmarked expressions' do
   context 'when user logged in' do
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item3, 3, expression: FactoryBot.create(:empty_note)) }
     let(:user) { FactoryBot.build(:user) }
 
     before do

--- a/spec/system/expressions/expression_delete_spec.rb
+++ b/spec/system/expressions/expression_delete_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Expressions' do
   describe 'delete first expression' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
 
     before do
       OmniAuth.config.test_mode = true
@@ -93,7 +93,7 @@ RSpec.describe 'Expressions' do
   describe 'delete another expression' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:note, user_id: user.id)) }
 
     before do
       OmniAuth.config.test_mode = true

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Expressions' do
 
       it 'check next button' do
         first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-        second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        second_expression_items = FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:note))
 
         visit '/'
         click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
@@ -187,7 +187,7 @@ RSpec.describe 'Expressions' do
 
       it 'check back button' do
         first_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-        second_expression_items = FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
+        second_expression_items = FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:note))
 
         visit '/'
         click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
@@ -202,8 +202,8 @@ RSpec.describe 'Expressions' do
     context 'when the expressions page is visited through bookmarked expressions list' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
       before do
         FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
@@ -280,8 +280,8 @@ RSpec.describe 'Expressions' do
     context 'when the expression page is visited through memorised expression list' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
       before do
         FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
@@ -360,7 +360,7 @@ RSpec.describe 'Expressions' do
     let!(:user) { FactoryBot.create(:user) }
     let(:new_user) { FactoryBot.build(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
     it 'check if user who does not own the expressions can not see it' do
       OmniAuth.config.test_mode = true

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe 'Expressions' do
   context 'when user has not logged in' do
     let(:new_user) { FactoryBot.build(:user) }
     let!(:two_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:three_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
-    let!(:four_expression_items) { FactoryBot.create_list(:expression_item, 4, expression: FactoryBot.create(:empty_note)) }
-    let!(:five_expression_items) { FactoryBot.create_list(:expression_item, 5, expression: FactoryBot.create(:empty_note)) }
+    let!(:three_expression_items) { FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note)) }
+    let!(:four_expression_items) { FactoryBot.create_list(:expression_item3, 4, expression: FactoryBot.create(:empty_note)) }
+    let!(:five_expression_items) { FactoryBot.create_list(:expression_item4, 5, expression: FactoryBot.create(:empty_note)) }
 
     before do
       16.times do
@@ -57,7 +57,7 @@ RSpec.describe 'Expressions' do
     before do
       10.times do
         FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:note))
-        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+        FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note))
       end
 
       OmniAuth.config.test_mode = true
@@ -96,9 +96,9 @@ RSpec.describe 'Expressions' do
   context 'when a user who has bookmarks has logged in' do
     let(:new_user) { FactoryBot.build(:user) }
     let!(:two_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-    let!(:three_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
-    let!(:four_expression_items) { FactoryBot.create_list(:expression_item, 4, expression: FactoryBot.create(:empty_note)) }
-    let!(:five_expression_items) { FactoryBot.create_list(:expression_item, 5, expression: FactoryBot.create(:empty_note)) }
+    let!(:three_expression_items) { FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note)) }
+    let!(:four_expression_items) { FactoryBot.create_list(:expression_item3, 4, expression: FactoryBot.create(:empty_note)) }
+    let!(:five_expression_items) { FactoryBot.create_list(:expression_item4, 5, expression: FactoryBot.create(:empty_note)) }
 
     before do
       OmniAuth.config.test_mode = true
@@ -161,8 +161,10 @@ RSpec.describe 'Expressions' do
   context 'when a user who has memorised words logged in' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:expression) { FactoryBot.create(:empty_note, user_id: user.id) }
+    let!(:first_expression_item) { FactoryBot.create(:expression_item3, expression:) }
+    let!(:second_expression_item) { FactoryBot.create(:expression_item4, expression:) }
 
     before do
       FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
@@ -177,17 +179,17 @@ RSpec.describe 'Expressions' do
 
     it 'check list of expressions' do
       expect(all('li').count).to eq 1
-      expect(page).to have_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}",
-                                href: expression_path(ExpressionItem.where(content: third_expression_items[0].content).last.expression)
+      expect(page).to have_link "#{first_expression_item.content} and #{second_expression_item.content}",
+                                href: expression_path(ExpressionItem.where(content: first_expression_item.content).last.expression)
     end
 
     it 'check if list of expressions has no data after adding all expressions to memorised words list' do
       visit '/quiz'
       2.times do |n|
-        if has_text?(third_expression_items[0].explanation)
-          fill_in('解答を入力', with: third_expression_items[0].content)
-        elsif has_text?(third_expression_items[1].explanation)
-          fill_in('解答を入力', with: third_expression_items[1].content)
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
         end
         click_button 'クイズに解答する'
         n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')

--- a/spec/system/memorised_expressions_spec.rb
+++ b/spec/system/memorised_expressions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Memorised expressions' do
 
       before do
         FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note))
-        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+        FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note))
 
         OmniAuth.config.test_mode = true
         OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
@@ -29,12 +29,16 @@ RSpec.describe 'Memorised expressions' do
     context 'when there are data of memorisings' do
       let!(:user) { FactoryBot.create(:user) }
       let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
       before do
         expressions = []
-        10.times do
+        2.times do
           expressions.push(FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)))
+          expressions.push(FactoryBot.create_list(:expression_item2, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)))
+          expressions.push(FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)))
+          expressions.push(FactoryBot.create_list(:expression_item4, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)))
+          expressions.push(FactoryBot.create_list(:expression_item5, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)))
         end
 
         FactoryBot.create(:memorising, user:, expression: first_expression_items[0].expression)
@@ -72,9 +76,12 @@ RSpec.describe 'Memorised expressions' do
 
     context 'when memorisings were made by two different times' do
       let!(:user) { FactoryBot.create(:user) }
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:expression) { FactoryBot.create(:empty_note, user_id: user.id) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
+
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item4, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
       before do
         FactoryBot.create(:memorising, user:, expression: second_expression_items[0].expression)
@@ -89,10 +96,10 @@ RSpec.describe 'Memorised expressions' do
         visit '/quiz'
 
         2.times do |n|
-          if has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          if has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -107,8 +114,8 @@ RSpec.describe 'Memorised expressions' do
                                          href: expression_path(ExpressionItem.where(content: second_expression_items[0].content).last.expression)
         expect(all('li')[1]).to have_link "#{third_expression_items[0].content}, #{third_expression_items[1].content} and #{third_expression_items[2].content}",
                                           href: expression_path(ExpressionItem.where(content: third_expression_items[0].content).last.expression)
-        expect(all('li').last).to have_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}",
-                                            href: expression_path(ExpressionItem.where(content: first_expression_items[0].content).last.expression)
+        expect(all('li').last).to have_link "#{first_expression_item.content} and #{second_expression_item.content}",
+                                            href: expression_path(ExpressionItem.where(content: first_expression_item.content).last.expression)
       end
     end
   end

--- a/spec/system/quizzes_spec.rb
+++ b/spec/system/quizzes_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Quiz' do
   describe 'questions' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-    let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
-    let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:second_expression_items) { FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
+    let!(:third_expression_items) { FactoryBot.create_list(:expression_item3, 3, expression: FactoryBot.create(:empty_note, user_id: user.id)) }
 
     before do
       FactoryBot.create(:bookmarking, user:, expression: first_expression_items[0].expression)
@@ -224,7 +224,9 @@ RSpec.describe 'Quiz' do
     end
 
     context 'when one expression is in the list that go to bookmark and one expression is in the list that go to memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
       let(:answers) { [] } # クイズの問題がランダムに出題されるため、クイズで入力した値をexampleで取得できるようにbeforeでこの配列に値を代入
 
       before do
@@ -239,10 +241,10 @@ RSpec.describe 'Quiz' do
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
             answers.push('veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
 
           click_button 'クイズに解答する'
@@ -256,9 +258,9 @@ RSpec.describe 'Quiz' do
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         if answers.count == 2
           expect(page).to have_content 'balcony and Veranda'
-          expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).not_to have_content "#{first_expression_item.content} and #{second_expression_item.content}"
         else
-          expect(page).to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).to have_content "#{first_expression_item.content} and #{second_expression_item.content}"
           expect(page).not_to have_content 'balcony and Veranda'
         end
 
@@ -270,11 +272,11 @@ RSpec.describe 'Quiz' do
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         if answers.count == 2
-          expect(page).to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).to have_content "#{first_expression_item.content} and #{second_expression_item.content}"
           expect(page).not_to have_content 'balcony and Veranda'
         else
           expect(page).to have_content 'balcony and Veranda'
-          expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+          expect(page).not_to have_content "#{first_expression_item.content} and #{second_expression_item.content}"
         end
 
         expect(all('ul.list-of-wrong-answers li').count).to eq 1
@@ -282,7 +284,10 @@ RSpec.describe 'Quiz' do
     end
 
     context 'when two expressions are in memorised words list and zero expression is in bookmark list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 3, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
+      let!(:third_expression_item) { FactoryBot.create(:expression_item3, expression:) }
 
       before do
         visit '/quiz'
@@ -291,12 +296,12 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
-          elsif has_text?(first_expression_items[2].explanation)
-            fill_in('解答を入力', with: first_expression_items[2].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
+          elsif has_text?(third_expression_item.explanation)
+            fill_in('解答を入力', with: third_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -310,7 +315,7 @@ RSpec.describe 'Quiz' do
 
         expect(first('ul.list-of-correct-answers li')).to have_content 'balcony and Veranda'
         expect(all('ul.list-of-correct-answers li')[1]).to have_content(
-          "#{first_expression_items[0].content}, #{first_expression_items[1].content} and #{first_expression_items[2].content}"
+          "#{first_expression_item.content}, #{second_expression_item.content} and #{third_expression_item.content}"
         )
 
         expect(page).not_to have_selector 'div.section-of-wrong-answers'
@@ -351,7 +356,9 @@ RSpec.describe 'Quiz' do
     end
 
     describe 'checkbox for memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
 
       before do
         visit '/quiz'
@@ -360,10 +367,10 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 3 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -374,7 +381,7 @@ RSpec.describe 'Quiz' do
         expect(page).to have_checked_field 'move-to-memorised-list'
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         expect(page).to have_checked_field 'balcony and Veranda'
-        expect(page).to have_checked_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).to have_checked_field "#{first_expression_item.content} and #{second_expression_item.content}"
       end
 
       it 'check if the parents checkbox is unchecked when one expression is unchecked' do
@@ -383,7 +390,7 @@ RSpec.describe 'Quiz' do
         find('label', text: 'balcony and Veranda').click
         expect(page).to have_unchecked_field 'balcony and Veranda'
         expect(page).to have_unchecked_field 'move-to-memorised-list'
-        expect(page).to have_checked_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).to have_checked_field "#{first_expression_item.content} and #{second_expression_item.content}"
       end
 
       it 'check if parents checkbox is checked after one child checkbox is unchecked and then it is checked again' do
@@ -401,7 +408,7 @@ RSpec.describe 'Quiz' do
         expect(page).to have_unchecked_field 'move-to-memorised-list'
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         expect(page).to have_unchecked_field 'balcony and Veranda'
-        expect(page).to have_unchecked_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).to have_unchecked_field "#{first_expression_item.content} and #{second_expression_item.content}"
       end
     end
 
@@ -596,7 +603,9 @@ RSpec.describe 'Quiz' do
     end
 
     describe 'save to memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
       let(:user) { FactoryBot.build(:user) }
 
       before do
@@ -614,10 +623,10 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 3 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -638,7 +647,7 @@ RSpec.describe 'Quiz' do
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         find('label', text: 'balcony and Veranda').click
         expect(page).to have_unchecked_field 'balcony and Veranda'
-        expect(page).to have_checked_field "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).to have_checked_field "#{first_expression_item.content} and #{second_expression_item.content}"
         expect do
           click_button '保存する'
           expect(page).not_to have_selector 'div.move-to-bookmark-or-memorised-list'
@@ -647,7 +656,7 @@ RSpec.describe 'Quiz' do
       end
 
       it 'check if one expression is saved to memorised words list even if another one is failed to save' do
-        expression_item = ExpressionItem.where(content: first_expression_items[0].content).last
+        expression_item = ExpressionItem.where(content: first_expression_item.content).last
         expression_id = expression_item.expression.id
         expression_item.expression.destroy
         expect(Expression.exists?(id: expression_id)).to be false
@@ -661,7 +670,7 @@ RSpec.describe 'Quiz' do
       it 'check notification when expressions are failed to saved in memorised words list' do
         expression_item = ExpressionItem.where(content: 'balcony').last
         expression_item.expression.destroy
-        expression_item2 = ExpressionItem.where(content: first_expression_items[0].content).last
+        expression_item2 = ExpressionItem.where(content: first_expression_item.content).last
         expression_item2.expression.destroy
         expect do
           click_button '保存する'
@@ -671,7 +680,7 @@ RSpec.describe 'Quiz' do
       end
 
       it 'check if expression is saved to memorised words list after failing to save another one' do
-        ExpressionItem.where(content: first_expression_items[0].content).last.expression.destroy
+        ExpressionItem.where(content: first_expression_item.content).last.expression.destroy
         find('summary', text: '覚えたリストに移動する英単語・フレーズ').click
         find('label', text: 'balcony and Veranda').click
         expect(page).to have_unchecked_field 'balcony and Veranda'
@@ -701,7 +710,7 @@ RSpec.describe 'Quiz' do
 
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         expect(page).to have_content 'balcony and Veranda'
-        expect(page).not_to have_content "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
+        expect(page).not_to have_content "#{first_expression_item.content} and #{second_expression_item.content}"
       end
     end
 
@@ -781,9 +790,12 @@ RSpec.describe 'Quiz' do
     end
 
     describe 'two expressions are bookmarked and two expressions are saved to memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-      let!(:third_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
+
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:third_expression_items) { FactoryBot.create_list(:expression_item4, 2, expression: FactoryBot.create(:empty_note)) }
       let(:user) { FactoryBot.build(:user) }
 
       before do
@@ -801,10 +813,10 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           elsif has_text?(second_expression_items[0].explanation)
             fill_in('解答を入力', with: '')
           elsif has_text?(second_expression_items[1].explanation)
@@ -831,7 +843,7 @@ RSpec.describe 'Quiz' do
       end
 
       it 'check if expressions are saved to memorised words list and bookmarked when one expression is failed to save to memorised words list' do
-        expression_item = ExpressionItem.where(content: first_expression_items[0].content).last
+        expression_item = ExpressionItem.where(content: first_expression_item.content).last
         expression_item.expression.destroy
 
         expect do
@@ -843,12 +855,15 @@ RSpec.describe 'Quiz' do
     end
 
     describe 'After bookmarking and saving expressions to memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
-      let!(:second_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
+
+      let!(:second_expression_items) { FactoryBot.create_list(:expression_item3, 2, expression: FactoryBot.create(:empty_note)) }
       let(:user) { FactoryBot.build(:user) }
 
       before do
-        FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+        FactoryBot.create_list(:expression_item4, 2, expression: FactoryBot.create(:empty_note))
 
         OmniAuth.config.test_mode = true
         OmniAuth.config.add_mock(:google_oauth2, { uid: user.uid, info: { name: user.name } })
@@ -864,10 +879,10 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 7 ? click_button('次へ') : click_button('クイズの結果を確認する')
@@ -952,7 +967,9 @@ RSpec.describe 'Quiz' do
     end
 
     describe 'show a message when user has not logged in and  there is checkbox for saving to memorised words list' do
-      let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
+      let!(:expression) { FactoryBot.create(:empty_note) }
+      let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+      let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
 
       before do
         visit '/quiz'
@@ -962,10 +979,10 @@ RSpec.describe 'Quiz' do
             fill_in('解答を入力', with: 'balcony')
           elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
             fill_in('解答を入力', with: 'veranda')
-          elsif has_text?(first_expression_items[0].explanation)
-            fill_in('解答を入力', with: first_expression_items[0].content)
-          elsif has_text?(first_expression_items[1].explanation)
-            fill_in('解答を入力', with: first_expression_items[1].content)
+          elsif has_text?(first_expression_item.explanation)
+            fill_in('解答を入力', with: first_expression_item.content)
+          elsif has_text?(second_expression_item.explanation)
+            fill_in('解答を入力', with: second_expression_item.content)
           end
           click_button 'クイズに解答する'
           n < 3 ? click_button('次へ') : click_button('クイズの結果を確認する')


### PR DESCRIPTION
## Issue
- #43 

## Summary
### ブックマークリストのクイズの最終結果画面を作成した。
- 英単語・フレーズをブックマークに移動する機能を非表示にした
- 正解した英単語・フレーズを覚えた語彙リストに移動させるのに保存するボタンを押した時、bookmarkingを作成するリクエストが飛ばないようにした。
- 英単語・フレーズがブックマークリストから覚えた語彙リストに保存先を変更するときに、bookmarkingは削除しmemorisingのみに英単語・フレーズが属するようにした。

### Flaky test
- クイズのテストで正解して欲しいコードがよく落ちていたので検証した。結果、factory_botで生成しているクイズの問題となるデータが原因で、そのデータの作成をFakerを使って行っているが、その作成されているデータがランダムではあるが時々全く同じものになっており、全く同じ問題が存在するが答えは異なる状況が発生していた。そういった問題が出題されたときプログラムが別の問題の答えを入力することで不正解となりテストが落ちるようになっていた。この問題も修正した。