### PR TITLE
Create quiz that starts from memorised list

### DIFF
--- a/app/controllers/api/memorised_expressions/quizzes_controller.rb
+++ b/app/controllers/api/memorised_expressions/quizzes_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Api::MemorisedExpressions::QuizzesController < ApplicationController
+  def show
+    @quiz = []
+
+    current_user.memorisings.each do |memorising|
+      expression = Expression.find memorising.expression_id
+      expression.expression_items.each { |expression_item| @quiz.push expression_item }
+    end
+  end
+end

--- a/app/controllers/memorised_expressions/quizzes_controller.rb
+++ b/app/controllers/memorised_expressions/quizzes_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MemorisedExpressions::QuizzesController < ApplicationController
+  def show
+    if logged_in?
+      return unless current_user.memorisings.count.zero?
+
+      redirect_to memorised_expressions_path, notice: t('.no_data')
+    else
+      redirect_to memorised_expressions_path
+    end
+  end
+end

--- a/app/views/api/memorised_expressions/quizzes/show.json.jbuilder
+++ b/app/views/api/memorised_expressions/quizzes/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @quiz do |resource|
+  json.content resource.content
+  json.explanation resource.explanation
+  json.expressionId resource.expression_id
+end

--- a/app/views/memorised_expressions/index.html.slim
+++ b/app/views/memorised_expressions/index.html.slim
@@ -8,3 +8,4 @@ p style="color: green" = notice
       = t('.unauthorized')
 - else
   div(data-vue='ExpressionsList' data-vue-path='api/memorised_expressions')
+  = link_to t('.start_quiz'), memorised_expressions_quiz_path

--- a/app/views/memorised_expressions/quizzes/show.html.slim
+++ b/app/views/memorised_expressions/quizzes/show.html.slim
@@ -1,0 +1,1 @@
+div(data-vue='WordQuiz' data-vue-path='/api/memorised_expressions/quiz')

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
     index:
       no_data: 覚えた語彙リストに登録している英単語またはフレーズはありません
       unauthorized: ログインしていないため閲覧できません
+      start_quiz: クイズに挑戦
+    quizzes:
+      show:
+        no_data: このリストのクイズに問題が存在しません
   users:
     confirm_deletion_of_account: "アカウントを削除しますか？\n \n重要:アカウントを削除すると、このアプリに登録した全てのデータは削除されます。"
     destroy:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   namespace :bookmarked_expressions do
     resource :quiz, only: [:show]
   end
+  namespace :memorised_expressions do
+    resource :quiz, only: [:show]
+  end
   namespace :api do
     resources :expressions, only: [:index, :edit]
     resource :quiz, only: [:show]
@@ -21,6 +24,9 @@ Rails.application.routes.draw do
     post '/bookmarked_expressions', to: 'bookmarkings#create'
     post '/memorised_expressions', to: 'memorisings#create'
     namespace :bookmarked_expressions do
+      resource :quiz, only: [:show]
+    end
+    namespace :memorised_expressions do
       resource :quiz, only: [:show]
     end
   end

--- a/spec/system/bookmarked_expressions/quizzes_spec.rb
+++ b/spec/system/bookmarked_expressions/quizzes_spec.rb
@@ -227,6 +227,7 @@ RSpec.describe 'BookmarkedExpressions Quiz' do
 
     it 'check if the page is bookmarks list' do
       expect(new_user.bookmarkings.count).to eq 0
+      visit bookmarked_expressions_path
       expect(page).not_to have_link 'クイズに挑戦'
       visit bookmarked_expressions_quiz_path
       expect(page).to have_current_path bookmarked_expressions_path

--- a/spec/system/memorised_expressions/quizzes_spec.rb
+++ b/spec/system/memorised_expressions/quizzes_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'MemorisedExpressions Quiz' do
+  context 'when user starts quiz from memorised list' do
+    let!(:user1) { FactoryBot.create(:user) }
+    let!(:expression1) { FactoryBot.create(:empty_note, user_id: user1.id) }
+    let!(:first_expression_item) { FactoryBot.create(:expression_item, expression: expression1) }
+    let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression: expression1) }
+
+    let!(:expression2) { FactoryBot.create(:empty_note, user_id: user1.id) }
+    let!(:third_expression_item) { FactoryBot.create(:expression_item3, expression: expression2) }
+    let!(:fourth_expression_item) { FactoryBot.create(:expression_item4, expression: expression2) }
+    let!(:fifth_expression_item) { FactoryBot.create(:expression_item5, expression: expression2) }
+
+    before do
+      third_expression_items = FactoryBot.create_list(:expression_item6, 3, expression: FactoryBot.create(:empty_note, user_id: user1.id))
+      FactoryBot.create_list(:expression_item6, 2, expression: FactoryBot.create(:empty_note, user_id: user1.id))
+      user2 = FactoryBot.create(:user)
+      fifth_expression_items = FactoryBot.create_list(:expression_item6, 2, expression: FactoryBot.create(:empty_note, user_id: user2.id))
+
+      FactoryBot.create(:memorising, user: user1, expression: first_expression_item.expression)
+      FactoryBot.create(:memorising, user: user1, expression: third_expression_item.expression)
+      FactoryBot.create(:memorising, user: user2, expression: fifth_expression_items[0].expression)
+      FactoryBot.create(:bookmarking, user: user1, expression: third_expression_items[0].expression)
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: user1.uid, info: { name: user1.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+
+      visit memorised_expressions_quiz_path
+    end
+
+    it 'check the questions are from memorised list' do
+      expect(page).to have_css 'p.content-of-question'
+      5.times do |n|
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(all('ul.user-answer-list li', visible: false).count).to eq 5
+      find('summary', text: '自分の解答を表示').click
+      expect(page).to have_content "Answer: #{first_expression_item.content}"
+      expect(page).to have_content "Answer: #{second_expression_item.content}"
+      expect(page).to have_content "Answer: #{third_expression_item.content}"
+      expect(page).to have_content "Answer: #{fourth_expression_item.content}"
+      expect(page).to have_content "Answer: #{fifth_expression_item.content}"
+    end
+
+    it 'check the questions and answers are set correctly' do
+      5.times do |n|
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        elsif has_text?(third_expression_item.explanation)
+          fill_in('解答を入力', with: third_expression_item.content)
+          click_button 'クイズに解答する'
+          expect(page).to have_content '◯ 正解!'
+        else
+          click_button 'クイズに解答する'
+        end
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+    end
+  end
+
+  context 'when new user starts quiz from memorised list' do
+    let(:new_user) { FactoryBot.build(:user) }
+    let!(:user) { FactoryBot.create(:user) }
+    let!(:expression) { FactoryBot.create(:empty_note) }
+    let!(:first_expression_item) { FactoryBot.create(:expression_item, expression:) }
+    let!(:second_expression_item) { FactoryBot.create(:expression_item2, expression:) }
+
+    before do
+      FactoryBot.create_list(:expression_item3, 3, expression: FactoryBot.create(:empty_note))
+      FactoryBot.create_list(:expression_item4, 2, expression: FactoryBot.create(:empty_note))
+      FactoryBot.create_list(:expression_item5, 2, expression: FactoryBot.create(:empty_note, user_id: user.id))
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+
+      visit '/quiz'
+      9.times do |n|
+        if has_text?('A platform on the side of a building, accessible from inside the building.')
+          fill_in('解答を入力', with: 'balcony')
+        elsif has_text?('A covered area in front of an entrance, normally on the ground floor and generally quite ornate or fancy, with room to sit.')
+          fill_in('解答を入力', with: 'Veranda')
+        elsif has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        end
+        click_button 'クイズに解答する'
+        n < 8 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      click_button '保存する'
+      has_text? 'ブックマーク・覚えた語彙リストに英単語・フレーズを保存しました！'
+
+      visit memorised_expressions_path
+    end
+
+    it 'check the questions are from memorisied list' do
+      expect(page).to have_link 'クイズに挑戦'
+      click_link 'クイズに挑戦'
+      expect(page).to have_css 'p.content-of-question'
+      4.times do |n|
+        click_button 'クイズに解答する'
+        n < 3 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      find('summary', text: '自分の解答を表示').click
+      expect(all('ul.user-answer-list li').count).to eq 4
+      expect(page).to have_content 'Answer: balcony'
+      expect(page).to have_content 'Answer: Veranda'
+      expect(page).to have_content "Answer: #{first_expression_item.content}"
+      expect(page).to have_content "Answer: #{second_expression_item.content}"
+    end
+  end
+
+  context 'when user does not have memorised expressions' do
+    let(:new_user) { FactoryBot.build(:user) }
+
+    before do
+      FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note))
+      FactoryBot.create_list(:expression_item2, 3, expression: FactoryBot.create(:empty_note))
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(:google_oauth2, { uid: new_user.uid, info: { name: new_user.name } })
+
+      visit '/'
+      click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
+    end
+
+    it 'check if the page is memorised list' do
+      expect(new_user.memorisings.count).to eq 0
+      visit memorised_expressions_path
+      expect(page).not_to have_link 'クイズに挑戦'
+      visit memorised_expressions_quiz_path
+      expect(page).to have_current_path memorised_expressions_path
+      expect(page).to have_content 'このリストのクイズに問題が存在しません'
+    end
+  end
+
+  context 'when user has not logged in' do
+    it 'check if the page is memorised list' do
+      visit memorised_expressions_path
+      expect(page).not_to have_link 'クイズに挑戦'
+
+      visit memorised_expressions_quiz_path
+      expect(page).to have_current_path memorised_expressions_path
+      expect(page).to have_content 'ログインしていないため閲覧できません'
+    end
+  end
+end


### PR DESCRIPTION
## Issue
- #133 

## Summary
覚えた語彙リストにクイズに挑戦ボタンを設置し、そこから覚えた語彙リストに登録されている英単語・フレーズのクイズを実施できるようにした。またクイズに挑戦ボタンは、覚えた語彙リストに英単語・フレーズが存在しない場合とログインしていない状態では表示されないようにした。