### PR TITLE
Create result page for quiz that starts from memorised list

### DIFF
--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -318,7 +318,9 @@ export default {
     createListOfItems() {
       this.classifyUserAnswersByExpressionId()
       this.classifyExpressionGroupsByRightOrWrong()
-      this.convertExpressionIds(this.allCorrectExpressionIds, 'correct')
+      if (!this.isMemorisedList) {
+        this.convertExpressionIds(this.allCorrectExpressionIds, 'correct')
+      }
       if (!this.isBookmarkedList) {
         this.convertExpressionIds(this.wrongExpressionIds, 'wrong')
       }
@@ -393,7 +395,7 @@ export default {
           })
         }
       })
-      this.sortItems(this.listOfCorrectItems)
+      if (!this.isMemorisedList) this.sortItems(this.listOfCorrectItems)
       if (!this.isBookmarkedList) this.sortItems(this.listOfWrongItems)
     },
     sortItems(items) {
@@ -423,10 +425,12 @@ export default {
         this.listOfWrongItems
       )
     }
-    this.defaultCheckbox(
-      this.checkedContentsToMemorisedList,
-      this.listOfCorrectItems
-    )
+    if (!this.isMemorisedList) {
+      this.defaultCheckbox(
+        this.checkedContentsToMemorisedList,
+        this.listOfCorrectItems
+      )
+    }
     this.checkExistenceOfMovableExpressions()
   }
 }

--- a/app/javascript/components/word-quiz-result.vue
+++ b/app/javascript/components/word-quiz-result.vue
@@ -40,7 +40,11 @@
       </details>
     </div>
     <div
-      v-if="listOfCorrectItems.length > 0 && !isSavedMemorisedList"
+      v-if="
+        listOfCorrectItems.length > 0 &&
+        !isSavedMemorisedList &&
+        !isMemorisedList
+      "
       class="section-of-correct-answers pt-2.5">
       <input
         type="checkbox"
@@ -145,6 +149,7 @@ export default {
       failure: [],
       unauthorized: false,
       isBookmarkedList: this.isBookmarkedExpressionsPath(),
+      isMemorisedList: this.isMemorisedExpressionsPath(),
       movableExpressionExists: true
     }
   },
@@ -397,8 +402,14 @@ export default {
     isBookmarkedExpressionsPath() {
       return location.pathname === '/bookmarked_expressions/quiz'
     },
+    isMemorisedExpressionsPath() {
+      return location.pathname === '/memorised_expressions/quiz'
+    },
     checkExistenceOfMovableExpressions() {
-      if (this.isBookmarkedList && this.listOfCorrectItems.length === 0) {
+      if (
+        (this.isBookmarkedList && this.listOfCorrectItems.length === 0) ||
+        (this.isMemorisedList && this.listOfWrongItems.length === 0)
+      ) {
         this.movableExpressionExists = false
       }
     }

--- a/app/models/concerns/recordable.rb
+++ b/app/models/concerns/recordable.rb
@@ -7,10 +7,8 @@ module Recordable
 
     transaction do
       exist_expression_ids.each do |expression_id|
-        if self == Memorising
-          bookmarking = Bookmarking.find_by(expression_id:)
-          bookmarking&.destroy
-        end
+        Bookmarking.find_by(expression_id:)&.destroy if self == Memorising
+        Memorising.find_by(expression_id:)&.destroy if self == Bookmarking
 
         object = new
         object.user_id = user_id

--- a/spec/models/example_spec.rb
+++ b/spec/models/example_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Example, type: :model do
     let!(:user) { FactoryBot.create(:user) }
     let!(:first_expression_items) { FactoryBot.create_list(:expression_item, 2, expression: FactoryBot.create(:empty_note)) }
     let!(:example1) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
-    let!(:example2) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
-    let!(:example3) { FactoryBot.create(:example, expression_item: first_expression_items[0]) }
+    let!(:example2) { FactoryBot.create(:example, content: Faker::Quote.yoda, expression_item: first_expression_items[0]) }
+    let!(:example3) { FactoryBot.create(:example, content: Faker::Quote.robin, expression_item: first_expression_items[0]) }
 
     it 'check if examples are copied' do
       new_expression = Expression.new

--- a/spec/system/bookmarked_expressions_spec.rb
+++ b/spec/system/bookmarked_expressions_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Bookmarked expressions' do
 
     context 'when there are no bookmarks' do
       it 'show a message that there are no bookmarks' do
+        expect(page).to have_content 'ログインしました'
         visit '/bookmarked_expressions'
         expect(page).to have_content user.name
         expect(all('li').count).to eq 0
@@ -28,6 +29,7 @@ RSpec.describe 'Bookmarked expressions' do
 
     context 'when there are bookmarks' do
       before do
+        has_text? 'ログインしました'
         visit '/quiz'
 
         9.times do |n|
@@ -39,6 +41,7 @@ RSpec.describe 'Bookmarked expressions' do
         find('summary', text: 'ブックマークする英単語・フレーズ').click
         find('label', text: 'balcony and Veranda').click
         click_button '保存する'
+        has_text? 'ブックマークしました！'
 
         visit '/bookmarked_expressions'
       end
@@ -66,6 +69,7 @@ RSpec.describe 'Bookmarked expressions' do
 
     context 'when bookmarks were made by two different times' do
       before do
+        has_text? 'ログインしました'
         visit '/quiz'
 
         9.times do |n|
@@ -113,6 +117,7 @@ RSpec.describe 'Bookmarked expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       visit '/quiz'
 

--- a/spec/system/expressions/expression_delete_spec.rb
+++ b/spec/system/expressions/expression_delete_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       visit "/expressions/#{first_expression_items[0].expression.id}"
       expect(page).to have_current_path root_path
       expect(page).to have_content '権限がないため閲覧できません'
@@ -32,6 +33,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       expect(Expression.where('user_id = ?', user1.id).count).to eq 0
       visit '/expressions/1'
       expect(page).not_to have_button '削除'
@@ -49,6 +51,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
     end
@@ -101,6 +104,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       visit "/expressions/#{second_expression_items[0].expression.id}"
     end
@@ -127,6 +131,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       click_link 'balcony and Veranda'
       accept_confirm do
         click_button '削除'

--- a/spec/system/expressions/expression_details_spec.rb
+++ b/spec/system/expressions/expression_details_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check next button' do
+        expect(page).to have_content 'ログインしました'
         visit '/bookmarked_expressions'
         click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
 
@@ -232,6 +233,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check back button' do
+        expect(page).to have_content 'ログインしました'
         visit '/bookmarked_expressions'
         click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
 
@@ -245,6 +247,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no next button when the expression is the last one' do
+        expect(page).to have_content 'ログインしました'
         visit '/bookmarked_expressions'
         click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
 
@@ -254,6 +257,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no back button if the expression is the first one' do
+        expect(page).to have_content 'ログインしました'
         visit '/bookmarked_expressions'
         click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
 
@@ -263,6 +267,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no back and next button when expression is one in a list' do
+        expect(page).to have_content 'ログインしました'
         first_expression_items[0].expression.destroy
         third_expression_items[0].expression.destroy
         expect(User.find(user.id).bookmarkings.count).to eq 1
@@ -296,6 +301,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check next button' do
+        expect(page).to have_content 'ログインしました'
         visit '/memorised_expressions'
         click_link "#{second_expression_items[0].content} and #{second_expression_items[1].content}"
 
@@ -310,6 +316,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check back button' do
+        expect(page).to have_content 'ログインしました'
         visit '/memorised_expressions'
         click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
 
@@ -323,6 +330,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no next button when the expression is the last one' do
+        expect(page).to have_content 'ログインしました'
         visit '/memorised_expressions'
         click_link "#{third_expression_items[0].content} and #{third_expression_items[1].content}"
 
@@ -332,6 +340,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no back button if the expression is the first one' do
+        expect(page).to have_content 'ログインしました'
         visit '/memorised_expressions'
         click_link "#{first_expression_items[0].content} and #{first_expression_items[1].content}"
 
@@ -341,6 +350,7 @@ RSpec.describe 'Expressions' do
       end
 
       it 'check if there is no back and next button when expression is one in a list' do
+        expect(page).to have_content 'ログインしました'
         first_expression_items[0].expression.destroy
         third_expression_items[0].expression.destroy
         expect(User.find(user.id).memorisings.count).to eq 1
@@ -368,6 +378,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
 
       visit "/expressions/#{first_expression_items[0].expression.id}"
       expect(page).to have_current_path root_path
@@ -387,6 +398,7 @@ RSpec.describe 'Expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       visit "/expressions/#{first_expression_items[0].expression.id}"
 
       within '.title' do

--- a/spec/system/expressions/expressions_form_spec.rb
+++ b/spec/system/expressions/expressions_form_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe 'Expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
         visit '/expressions/new'
 
         fill_in('１つ目の英単語 / フレーズ', with: 'word1')

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -74,12 +74,14 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check the list order before the note has been edited' do
+      expect(page).to have_content 'ログインしました'
       expression_item = ExpressionItem.where('content = ?', 'balcony').last
 
       expect(first('li')).to have_link 'balcony and Veranda', href: expression_path(expression_item.expression)
     end
 
     it 'check if the data is at the same place after the note has been edited' do
+      expect(page).to have_content 'ログインしました'
       click_link 'balcony and Veranda'
       click_link '編集'
       3.times { click_button '次へ' }
@@ -178,12 +180,14 @@ RSpec.describe 'Expressions' do
     end
 
     it 'check list of expressions' do
+      expect(page).to have_content 'ログインしました'
       expect(all('li').count).to eq 1
       expect(page).to have_link "#{first_expression_item.content} and #{second_expression_item.content}",
                                 href: expression_path(ExpressionItem.where(content: first_expression_item.content).last.expression)
     end
 
     it 'check if list of expressions has no data after adding all expressions to memorised words list' do
+      expect(page).to have_content 'ログインしました'
       visit '/quiz'
       2.times do |n|
         if has_text?(first_expression_item.explanation)

--- a/spec/system/memorised_expressions/quizzes_spec.rb
+++ b/spec/system/memorised_expressions/quizzes_spec.rb
@@ -70,6 +70,57 @@ RSpec.describe 'MemorisedExpressions Quiz' do
         n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
       end
     end
+
+    it 'check if a section of moving expressions to bookmark or memorised list is not on the result page when all answers were correct' do
+      5.times do |n|
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        elsif has_text?(third_expression_item.explanation)
+          fill_in('解答を入力', with: third_expression_item.content)
+        elsif has_text?(fourth_expression_item.explanation)
+          fill_in('解答を入力', with: fourth_expression_item.content)
+        elsif has_text?(fifth_expression_item.explanation)
+          fill_in('解答を入力', with: fifth_expression_item.content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).not_to have_selector('.section-of-correct-answers')
+      expect(page).not_to have_selector('.section-of-wrong-answers')
+      expect(page).not_to have_button '保存する'
+    end
+
+    it 'check if a message that recommends next action is not on the result page when a section of moving expressions is not there' do
+      5.times do |n|
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        elsif has_text?(third_expression_item.explanation)
+          fill_in('解答を入力', with: third_expression_item.content)
+        elsif has_text?(fourth_expression_item.explanation)
+          fill_in('解答を入力', with: fourth_expression_item.content)
+        elsif has_text?(fifth_expression_item.explanation)
+          fill_in('解答を入力', with: fifth_expression_item.content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).not_to have_content 'ブックマークや覚えたリストに英単語・フレーズを移動させた後は復習しましょう！'
+      expect(page).not_to have_content '重要: 一度この画面を離れると戻れません。今回の結果をブックマークや覚えたリストに移動させる場合は、下記ボタンをクリックする前に必ず行なってください。'
+    end
+
+    it 'check if a section of moving expressions to bookmarks list is on the result page when answers are wrong' do
+      5.times do |n|
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).not_to have_selector('.section-of-correct-answers')
+      expect(page).to have_selector('.section-of-wrong-answers')
+      expect(page).to have_button '保存する'
+    end
   end
 
   context 'when new user starts quiz from memorised list' do

--- a/spec/system/memorised_expressions/quizzes_spec.rb
+++ b/spec/system/memorised_expressions/quizzes_spec.rb
@@ -137,6 +137,35 @@ RSpec.describe 'MemorisedExpressions Quiz' do
       expect(page).to have_content 'ブックマークしました！'
       expect(page).not_to have_content '英単語・フレーズをブックマークしましたが覚えた語彙リストには保存できませんでした'
     end
+
+    it 'check if memorising is destroyed when bookmarking is created' do
+      5.times do |n|
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-wrong-answers')
+      expect do
+        click_button '保存する'
+        expect(page).to have_content 'ブックマークしました！'
+      end.to change(Bookmarking, :count).by(1).and change(Memorising, :count).by(-1)
+    end
+
+    it 'check if memorisings are destroyed when bookmarkings are created' do
+      5.times do |n|
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-wrong-answers')
+      expect do
+        click_button '保存する'
+        expect(page).to have_content 'ブックマークしました！'
+      end.to change(Bookmarking, :count).by(2).and change(Memorising, :count).by(-2)
+    end
   end
 
   context 'when new user starts quiz from memorised list' do

--- a/spec/system/memorised_expressions/quizzes_spec.rb
+++ b/spec/system/memorised_expressions/quizzes_spec.rb
@@ -121,6 +121,22 @@ RSpec.describe 'MemorisedExpressions Quiz' do
       expect(page).to have_selector('.section-of-wrong-answers')
       expect(page).to have_button '保存する'
     end
+
+    it 'check if request for saving memorising is not sent when bookmarking is saved' do
+      5.times do |n|
+        if has_text?(first_expression_item.explanation)
+          fill_in('解答を入力', with: first_expression_item.content)
+        elsif has_text?(second_expression_item.explanation)
+          fill_in('解答を入力', with: second_expression_item.content)
+        end
+        click_button 'クイズに解答する'
+        n < 4 ? click_button('次へ') : click_button('クイズの結果を確認する')
+      end
+      expect(page).to have_selector('.section-of-wrong-answers')
+      click_button '保存する'
+      expect(page).to have_content 'ブックマークしました！'
+      expect(page).not_to have_content '英単語・フレーズをブックマークしましたが覚えた語彙リストには保存できませんでした'
+    end
   end
 
   context 'when new user starts quiz from memorised list' do

--- a/spec/system/memorised_expressions_spec.rb
+++ b/spec/system/memorised_expressions_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Memorised expressions' do
       end
 
       it 'show a message that there are no data' do
+        expect(page).to have_content 'ログインしました'
         visit '/memorised_expressions'
         expect(page).to have_content user.name
         expect(all('li').count).to eq 0
@@ -92,6 +93,7 @@ RSpec.describe 'Memorised expressions' do
 
         visit '/'
         click_button 'Sign up/Log in with Google'
+        has_text? 'ログインしました'
 
         visit '/quiz'
 
@@ -105,6 +107,7 @@ RSpec.describe 'Memorised expressions' do
           n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
         end
         click_button '保存する'
+        has_text? '英単語・フレーズを覚えた語彙リストに保存しました！'
 
         visit '/memorised_expressions'
       end
@@ -129,6 +132,7 @@ RSpec.describe 'Memorised expressions' do
 
       visit '/'
       click_button 'Sign up/Log in with Google'
+      has_text? 'ログインしました'
 
       visit '/quiz'
 
@@ -142,7 +146,9 @@ RSpec.describe 'Memorised expressions' do
         n < 1 ? click_button('次へ') : click_button('クイズの結果を確認する')
       end
       click_button '保存する'
+      has_text? '英単語・フレーズを覚えた語彙リストに保存しました！'
 
+      visit '/'
       find('label', text: user.name).click
       click_button 'Log out'
     end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -14,14 +14,9 @@ RSpec.describe 'Sessions' do
     it 'check the function of login' do
       visit '/'
       click_button 'Sign up/Log in with Google'
+      expect(page).to have_content 'ログインしました'
       expect(page).to have_content user.name
       expect(page).not_to have_button 'Sign up/Log in with Google'
-    end
-
-    it 'show a message when login succeed' do
-      visit '/'
-      click_button 'Sign up/Log in with Google'
-      expect(page).to have_content 'ログインしました'
     end
 
     it 'check if current path is bookmarked_expressions after login' do
@@ -50,16 +45,19 @@ RSpec.describe 'Sessions' do
     end
 
     it 'the logout button is invisible before click user name' do
+      expect(page).to have_content 'ログインしました'
       expect(page).not_to have_button 'Log out'
     end
 
     it 'the logout button is visible after click user name' do
+      expect(page).to have_content 'ログインしました'
       find('label', text: user.name).click
       expect(page).not_to have_css('div.invisible', visible: :hidden)
       expect(page).to have_button 'Log out'
     end
 
     it 'check the function of logout' do
+      expect(page).to have_content 'ログインしました'
       find('label', text: user.name).click
       click_button 'Log out'
       expect(page).to have_button 'Sign up/Log in with Google'
@@ -67,6 +65,7 @@ RSpec.describe 'Sessions' do
     end
 
     it 'show a message when logout succeed' do
+      expect(page).to have_content 'ログインしました'
       find('label', text: user.name).click
       click_button 'Log out'
       expect(page).to have_content 'ログアウトしました'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Users' do
       end
 
       it 'check the function of deleting user account' do
+        expect(page).to have_content 'ログインしました'
         find('label', text: user.name).click
         click_button 'Delete account'
         expect do
@@ -56,6 +57,7 @@ RSpec.describe 'Users' do
       end
 
       it 'check if user is deleted' do
+        expect(page).to have_content 'ログインしました'
         find('label', text: user.name).click
         click_button 'Delete account'
         expect do
@@ -99,6 +101,7 @@ RSpec.describe 'Users' do
       end
 
       it 'check if user is deleted' do
+        expect(page).to have_content 'ログインしました'
         find('label', text: user.name).click
         click_button 'Delete account'
         expect do
@@ -152,6 +155,7 @@ RSpec.describe 'Users' do
       end
 
       it 'check if user is deleted' do
+        expect(page).to have_content 'ログインしました'
         find('label', text: user.name).click
         click_button 'Delete account'
         expect do


### PR DESCRIPTION
## Issue
- #44 

## Summary
覚えた語彙リストから実施したクイズの最終結果画面で覚えた語彙リストに英単語フレーズを保存する機能を非表示にした。
またこの最終結果画面で英単語フレーズをブックマークに保存した際に覚えたリストからは削除するようにした。