### PR TITLE
Add start quiz button on home page

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -16,3 +16,12 @@ p style="color: green" = notice
   - if flash[:unauthorized_access_to_create]
     = button_to 'Sign up/Log in with Google', '/auth/google_oauth2', method: :post, data: { turbo: false }
 = link_to "+ #{t('.create')}", new_expression_path
+
+- if logged_in?
+  = link_to t('.start_quiz'), quiz_path
+- else
+  .try-quiz
+    = link_to t('.try_quiz'), quiz_path
+    p
+      i class="fa-solid fa-circle-exclamation"
+      = t('.warning')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,7 @@ html
     = vite_client_tag
     = vite_javascript_tag 'application'
     = vite_stylesheet_tag 'application'
+    script src="https://kit.fontawesome.com/ce82121a9a.js" crossorigin="anonymous"
   body
     = render 'shared/header'
     main

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,9 @@ ja:
     index:
       no_data: このリストに登録されている英単語またはフレーズはありません
       create: 新規作成
+      start_quiz: クイズに挑戦
+      try_quiz: クイズを試してみる
+      warning: ブックマークや覚えた英単語・フレーズのリストに保存する機能を使用する場合は必ずログインしてからクイズに挑戦してください
   bookmarked_expressions:
     index:
       no_data: ブックマークしている英単語またはフレーズはありません

--- a/spec/system/bookmarked_expressions_spec.rb
+++ b/spec/system/bookmarked_expressions_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'Bookmarked expressions' do
       end
 
       it 'show a list of bookmarked expressions' do
-        expect(all('li').count).to eq 3
+        expect(all('li.expression').count).to eq 3
         expect(page).not_to have_content 'ブックマークしている英単語またはフレーズはありません'
         expect(page).not_to have_content 'ログインしていないため閲覧できません'
       end

--- a/spec/system/expressions/expressions_list_spec.rb
+++ b/spec/system/expressions/expressions_list_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe 'Expressions' do
       expect(page).to have_current_path memorised_expressions_path
       expect(page).to have_content 'ログインしていないため閲覧できません'
     end
+
+    it 'check a quiz button' do
+      expect(page).to have_link 'クイズを試してみる'
+      expect(page).to have_content 'ブックマークや覚えた英単語・フレーズのリストに保存する機能を使用する場合は必ずログインしてからクイズに挑戦してください'
+      click_link 'クイズを試してみる'
+      expect(page).to have_current_path '/quiz'
+      expect(page).to have_selector 'p.content-of-question'
+    end
   end
 
   context 'when new user logged in' do
@@ -127,6 +135,13 @@ RSpec.describe 'Expressions' do
       end
       expect(page).to have_current_path memorised_expressions_path
       expect(page).to have_content 'このリストに登録している英単語またはフレーズはありません'
+    end
+
+    it 'check a quiz button' do
+      expect(page).to have_link 'クイズに挑戦'
+      click_link 'クイズに挑戦'
+      expect(page).to have_current_path '/quiz'
+      expect(page).to have_selector 'p.content-of-question'
     end
   end
 


### PR DESCRIPTION
## Issue
- #51 

## Summary
ログインしているときは```クイズに挑戦```ボタンをデフォルトリストに表示し、ログインしていない時は```クイズを試してみる```ボタンとログインするとブックマークや覚えた英単語・フレーズのリストに保存できるようになることを伝える文言を表示させた。